### PR TITLE
#29 allow underscores and dashes in the template variable names

### DIFF
--- a/app/de/frosner/broccoli/models/Template.scala
+++ b/app/de/frosner/broccoli/models/Template.scala
@@ -23,7 +23,7 @@ case class Template(id: String, template: String, description: String) extends S
 
 object Template {
 
-  val TemplatePattern = Pattern.compile("\\{\\{([A-Za-z][A-Za-z0-9\\_]*)\\}\\}")
+  val TemplatePattern = Pattern.compile("\\{\\{([A-Za-z][A-Za-z0-9\\-\\_\\_]*)\\}\\}")
 
   implicit val templateWrites: Writes[Template] = (
     (JsPath \ "id").write[String] and

--- a/test/de/frosner/broccoli/models/TemplateSpec.scala
+++ b/test/de/frosner/broccoli/models/TemplateSpec.scala
@@ -20,6 +20,14 @@ class TemplateSpec extends Specification {
       Template("test", "Hallo {{name}}. I like {{name}}.", "desc").parameters === Set("name")
     }
 
+    "support dashes in the parameter names" in {
+      Template("test", "Hallo {{person-name}}", "desc").parameters === Set("person-name")
+    }
+
+    "support underscores in the parameter names" in {
+      Template("test", "Hallo {{person_name}}", "desc").parameters === Set("person_name")
+    }
+
   }
 
   "Template serialization" should {


### PR DESCRIPTION
Fixes #29 
