### PR TITLE
#98 copy example templates also to production docker image

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -2,4 +2,6 @@ FROM openjdk:8-jre
 
 COPY cluster-broccoli-dist /cluster-broccoli
 
+COPY templates /templates
+
 ENTRYPOINT ["/cluster-broccoli/bin/cluster-broccoli"]


### PR DESCRIPTION
```
docker run -p 9000:9000 frosner/cluster-broccoli:travis-218
[info] application - Looking for templates in templates
[info] application - Found 3 template directories: templates/zeppelin, templates/jupyter, templates/http-server
[info] play.api.Play - Application started (Prod)
[info] application - Successfully parsed 3 templates: zeppelin, jupyter, http-server
[info] p.c.s.NettyServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
[info] application - Locking instances (instances.lock)
[info] application - Advertising Consul entities through IP addresses.
[info] application - Looking for instances in instances.
[info] application - Instances file instances not found. Initializing with an empty instance collection.
```

Fixes #98 
