### PR TITLE
WIP: Move settings to application.conf

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -17,3 +17,11 @@ broccoli.auth.conf.accounts=[
   {username:user, password:user, instanceRegex=".*", role:"user"},
   {username:test, password:test, instanceRegex="^test.*", role:"administrator"}
 ]
+
+broccoli {
+  # Nomad URL to access the HTTP API
+  nomad.url = "http://localhost:4646"
+
+  # Path to Broccoli templates
+  templates.path = "./templates"
+}

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -1,4 +1,0 @@
-broccoli {
-  nomad.url = "http://localhost:4646"
-  templates.path = "./templates"
-}


### PR DESCRIPTION
We don't really need a reference.conf imho since we don't have
multiple configurations in our application.