### PR TITLE
Prevent npm publish in webui

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webapp",
+  "name": "webui",
   "version": "1.0.0",
   "description": "",
   "main": "webpack.config.js",

--- a/webui/package.json
+++ b/webui/package.json
@@ -2,7 +2,6 @@
   "name": "webui",
   "version": "1.0.0",
   "description": "",
-  "main": "webpack.config.js",
   "dependencies": {},
   "devDependencies": {
     "@panosoft/elm-native-helpers": "^0.1.10",

--- a/webui/package.json
+++ b/webui/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "dependencies": {},
+  "private": true,
   "devDependencies": {
     "@panosoft/elm-native-helpers": "^0.1.10",
     "animate.css": "^3.5.2",


### PR DESCRIPTION
Builds on #258 (because renaming), and simply sets `private: true` for the NPM package to prevent an accidental `npm publish` actually publishing to the NPM registry.