### PR TITLE
Add HTTP client to get allocations from Nomad API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val server = project
       Dependencies.commonsIO % Test,
       Dependencies.scalaguice
     ),
+    libraryDependencies ++= Dependencies.cats.map(_ % IntegrationTest),
     libraryDependencies ++= Dependencies.enumeratum,
     libraryDependencies ++= Dependencies.specs2.map(_ % Test),
     libraryDependencies ++= Dependencies.specs2.map(_ % IntegrationTest),

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,9 @@ lazy val server = project
       Dependencies.scalaguice
     ),
     libraryDependencies ++= Dependencies.enumeratum,
+    libraryDependencies ++= Dependencies.specs2.map(_ % Test),
+    libraryDependencies ++= Dependencies.specs2.map(_ % IntegrationTest),
+    libraryDependencies += Dependencies.scalacheck % Test,
     libraryDependencies ++= Dependencies.play2auth,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "de.frosner.broccoli.build",

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,12 @@ lazy val server = project
     libraryDependencies ++= Dependencies.play2auth,
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "de.frosner.broccoli.build",
-    PlayKeys.playMonitoredFiles ++= (sourceDirectories in (Compile, TwirlKeys.compileTemplates)).value
+    PlayKeys.playMonitoredFiles ++= (sourceDirectories in (Compile, TwirlKeys.compileTemplates)).value,
+    // Do not run integration tests in parallel, because these spawn docker containers and thus depend on global state
+    parallelExecution in IntegrationTest := false,
+    // Do not run unit tests in parallel either because Play doesn't like it
+    // Play doesn't like parallel tests with all its state
+    parallelExecution in Test := false
   )
   .dependsOn(webui)
 
@@ -63,9 +68,7 @@ lazy val root = project
           "-Ywarn-nullary-override",
           // Warn when numerics are unintentionally widened
           "-Ywarn-numeric-widen"
-        ),
-        // Play doesn't like parallel tests with all its state
-        parallelExecution in Test := false
+        )
       ))
   )
   .aggregate(webui, server)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,6 +2,12 @@ import sbt._
 
 object Dependencies {
   object Versions {
+    // Note: Do not update to 1.13.x; specs2-scalacheck 3.6.6 requires Scalacheck 2.12.5 and does not work with 1.13.x
+    val scalacheck = "1.12.5"
+
+    // Note: Do not update; play2-specs requires specs2 3.6.6 and throws exceptions with newer versions
+    val specs2 = "3.6.6"
+
     val play2auth = "0.14.2"
   }
 
@@ -13,6 +19,17 @@ object Dependencies {
     // Keep this version at 1.5.11 for compatibility with Play 2.5; later versions depend on Play 2.6 already
     "com.beachape" %% "enumeratum-play-json" % "1.5.11"
   )
+
+  /**
+    * Property testing for Scala.
+    */
+  val scalacheck: ModuleID = "org.scalacheck" %% "scalacheck" % Versions.scalacheck
+
+  /**
+    * Specs2 test framework, with support for property testing.
+    */
+  val specs2: Seq[ModuleID] = Seq("core", "scalacheck")
+    .map(module => "org.specs2" %% s"specs2-$module" % Versions.specs2)
 
   /**
     * Scala syntax for Guice, to declare custom modules

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,18 @@ object Dependencies {
     val specs2 = "3.6.6"
 
     val play2auth = "0.14.2"
+
+    val cats = "0.9.0"
   }
+
+  /**
+    * Functional programming data types and type classes.
+    */
+  val cats: Seq[ModuleID] = Seq(
+    "macros",
+    "kernel",
+    "core"
+  ).map(module => "org.typelevel" %% s"cats-$module" % Versions.cats)
 
   /**
     * A powerful enumeration type for Scala.

--- a/server/src/it/scala/de/frosner/broccoli/nomad/NomadHttpClientIntegrationSpec.scala
+++ b/server/src/it/scala/de/frosner/broccoli/nomad/NomadHttpClientIntegrationSpec.scala
@@ -1,28 +1,66 @@
 package de.frosner.broccoli.nomad
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import de.frosner.broccoli.test.contexts.WSClientContext
+import de.frosner.broccoli.test.contexts.docker.BroccoliDockerContext
+import de.frosner.broccoli.test.contexts.docker.BroccoliTestService.{Broccoli, Nomad}
+import org.scalacheck.Gen
 import org.specs2.concurrent.ExecutionEnv
-import org.specs2.execute.{AsResult, Result}
-import org.specs2.mutable.{After, Specification}
-import org.specs2.specification.ForEach
+import org.specs2.mutable.Specification
 import org.specs2.specification.mutable.ExecutionEnvironment
+import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
-import play.api.libs.ws.ahc.AhcWSClient
 
-class NomadHttpClientIntegrationSpec extends Specification with WSClientContext with ExecutionEnvironment {
+import scala.concurrent.blocking
+import scala.concurrent.duration._
+
+class NomadHttpClientIntegrationSpec
+    extends Specification
+    with WSClientContext
+    with BroccoliDockerContext
+    with ExecutionEnvironment {
+
+  /**
+    * Start Broccoli and Nomad for our tests.  We need Broccoli to spawn instances, and Nomad to test the client.
+    */
+  override def broccoliDockerConfig: BroccoliDockerContext.Configuration =
+    BroccoliDockerContext.Configuration.services(Broccoli, Nomad)
+
   private val baseUrl = "http://localhost:4646"
+  private val broccoliURL = "http://localhost:9000"
 
   override def is(implicit executionEnv: ExecutionEnv): Any =
     "The NomadHttpClient" should {
       "get allocations for a running nomad job" >> { wsClient: WSClient =>
+        // Generate a random identifier for the instance
+        val identifier = Gen.resize(10, Gen.identifier).sample.get
         val client = new NomadHttpClient(baseUrl, wsClient)
         (for {
-          allocations <- client.getAllocationsForJob("test")
+          // Create and start a simple instance to look at it's allocations
+          _ <- wsClient
+            .url(s"$broccoliURL/api/v1/instances")
+            .post(
+              Json.obj("templateId" -> "http-server",
+                       "parameters" -> Json.obj(
+                         "id" -> identifier
+                       )))
+            .map(response => {
+              // Ensure that the
+              response.status must beEqualTo(201)
+              response
+            })
+          _ <- wsClient
+            .url(s"$broccoliURL/api/v1/instances/$identifier")
+            .post(Json.obj("status" -> "running"))
+            .map(response => {
+              response.status must beEqualTo(200)
+              // Wait until the service is up
+              blocking(Thread.sleep(1.seconds.toMillis))
+              response
+            })
+          allocations <- client.getAllocationsForJob(identifier)
         } yield {
-          (allocations.jobId === "test") and (allocations.payload must have length (1))
-        }).await
+          (allocations.jobId === identifier) and (allocations.payload must have length 1)
+        }).await(5, broccoliDockerConfig.startupPatience + 2.seconds)
       }
     }
 }

--- a/server/src/it/scala/de/frosner/broccoli/nomad/NomadHttpClientIntegrationSpec.scala
+++ b/server/src/it/scala/de/frosner/broccoli/nomad/NomadHttpClientIntegrationSpec.scala
@@ -1,0 +1,28 @@
+package de.frosner.broccoli.nomad
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import de.frosner.broccoli.test.contexts.WSClientContext
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.{AsResult, Result}
+import org.specs2.mutable.{After, Specification}
+import org.specs2.specification.ForEach
+import org.specs2.specification.mutable.ExecutionEnvironment
+import play.api.libs.ws.WSClient
+import play.api.libs.ws.ahc.AhcWSClient
+
+class NomadHttpClientIntegrationSpec extends Specification with WSClientContext with ExecutionEnvironment {
+  private val baseUrl = "http://localhost:4646"
+
+  override def is(implicit executionEnv: ExecutionEnv): Any =
+    "The NomadHttpClient" should {
+      "get allocations for a running nomad job" >> { wsClient: WSClient =>
+        val client = new NomadHttpClient(baseUrl, wsClient)
+        (for {
+          allocations <- client.getAllocationsForJob("test")
+        } yield {
+          (allocations.jobId === "test") and (allocations.payload must have length (1))
+        }).await
+      }
+    }
+}

--- a/server/src/it/scala/de/frosner/broccoli/test/contexts/WSClientContext.scala
+++ b/server/src/it/scala/de/frosner/broccoli/test/contexts/WSClientContext.scala
@@ -1,0 +1,30 @@
+package de.frosner.broccoli.test.contexts
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.specs2.execute.{AsResult, Result}
+import org.specs2.specification.ForEach
+import org.specs2.specification.mutable.ExecutionEnvironment
+import play.api.libs.ws.WSClient
+import play.api.libs.ws.ahc.AhcWSClient
+
+/**
+  * Provides a WSClient instance to tests.
+  *
+  * Requires the ExecutionEnvironment to be mixed in.
+  */
+trait WSClientContext extends ForEach[WSClient] {
+  self: ExecutionEnvironment =>
+
+  override protected def foreach[R: AsResult](f: (WSClient) => R): Result = {
+    implicit val actorSystem = ActorSystem("nomad-http-client")
+    try {
+      implicit val materializer = ActorMaterializer()
+      val client: WSClient = AhcWSClient()
+      try AsResult(f(client))
+      finally client.close()
+    } finally {
+      actorSystem.terminate()
+    }
+  }
+}

--- a/server/src/it/scala/de/frosner/broccoli/test/contexts/docker/BroccoliDockerContext.scala
+++ b/server/src/it/scala/de/frosner/broccoli/test/contexts/docker/BroccoliDockerContext.scala
@@ -1,0 +1,102 @@
+package de.frosner.broccoli.test.contexts.docker
+
+import cats.instances.all._
+import cats.syntax.all._
+import org.specs2.control.Debug
+import org.specs2.execute.{AsResult, Result}
+import org.specs2.specification.AroundEach
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.sys.process._
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Start configured services from the Broccoli Test image before the test and stop-kill all containers after every
+  * test.
+  *
+  * Note that docker typically requires root privileges so this class uses "sudo" to start docker images.  To run tests
+  * seamlessly configure sudo to not ask for password for docker commands.
+  */
+trait BroccoliDockerContext extends AroundEach {
+
+  /**
+    * Configuration for the broccoli docker image.
+    */
+  def broccoliDockerConfig: BroccoliDockerContext.Configuration
+
+  override def around[T: AsResult](t: => T): Result = {
+    val containers = spawnContainers()
+    try {
+      // Wait for the services to come up
+      Thread.sleep(broccoliDockerConfig.startupPatience.toMillis)
+      AsResult(t)
+    } finally {
+      stopContainers(containers)
+    }
+  }
+
+  private type ContainerHandle = String
+
+  private def spawnContainers(): List[ContainerHandle] = {
+    val handles = broccoliDockerConfig.services.toList
+      .map { service =>
+        spawnContainer(service)
+      }
+    // Go through all started containers; throw the first exception seen, or return all handles if successful
+    handles.sequence[Try, ContainerHandle] match {
+      case Success(h)   => h
+      case Failure(exc) =>
+        // Stop all running containers and then throw the error
+        stopContainers(handles.collect {
+          case Success(h) => h
+        })
+        throw exc
+    }
+  }
+
+  private def stopContainers(handles: List[ContainerHandle]): Unit =
+    // Stop all containers, throwing the first exception seen
+    handles.map(stopContainer).sequence_.get
+
+  private def spawnContainer(service: BroccoliTestService): Try[ContainerHandle] = Try {
+    (Seq(
+      "sudo", // Docker requires root.
+      "docker",
+      "run",
+      "--rm", // Automatically remove the container when its stopped
+      "-d", // Detach into background
+      "--net",
+      "host", // Use host network to interconnect all services
+      "frosner/cluster-broccoli-test"
+    ) ++ service.command).!!.trim
+  }
+
+  private def stopContainer(handle: ContainerHandle): Try[Unit] =
+    Try {
+      Seq("sudo", "docker", "stop", handle).!!
+      ()
+    }
+}
+
+object BroccoliDockerContext {
+
+  /**
+    * Configuration for the Broccoli Docker Context.
+    *
+    * @param services Services to start
+    * @param startupPatience Time to wait after container startup
+    */
+  final case class Configuration(services: Set[BroccoliTestService], startupPatience: FiniteDuration)
+
+  object Configuration {
+
+    /**
+      *
+      * @param services
+      * @return
+      */
+    def services(service: BroccoliTestService, services: BroccoliTestService*): Configuration =
+      Configuration(services.toSet + service, 3.seconds)
+  }
+}

--- a/server/src/it/scala/de/frosner/broccoli/test/contexts/docker/BroccoliTestService.scala
+++ b/server/src/it/scala/de/frosner/broccoli/test/contexts/docker/BroccoliTestService.scala
@@ -1,0 +1,42 @@
+package de.frosner.broccoli.test.contexts.docker
+
+import enumeratum._
+
+sealed trait BroccoliTestService extends EnumEntry {
+
+  /**
+    * The command to run for this service.
+    */
+  def command: Seq[String]
+}
+
+/**
+  * Services that the Broccoli Test image provides
+  */
+object BroccoliTestService extends Enum[BroccoliTestService] {
+  val values = findValues
+
+  case object Broccoli extends BroccoliTestService {
+
+    /**
+      * The command to run for this service.
+      */
+    override def command: Seq[String] = Seq("cluster-broccoli")
+  }
+
+  case object Nomad extends BroccoliTestService {
+
+    /**
+      * The command to run for this service.
+      */
+    override def command: Seq[String] = Seq("nomad")
+  }
+
+  case object Consul extends BroccoliTestService {
+
+    /**
+      * The command to run for this service.
+      */
+    override def command: Seq[String] = Seq("consul")
+  }
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
@@ -1,0 +1,20 @@
+package de.frosner.broccoli.nomad
+
+import de.frosner.broccoli.nomad.models.{Allocation, WithId}
+
+import scala.collection.immutable
+import scala.concurrent.Future
+
+/**
+  * A client for Nomad.
+  */
+trait NomadClient {
+
+  /**
+    * Get allocations for a job.
+    *
+    * @param jobId The ID of the job
+    * @return The list of allocations for the job
+    */
+  def getAllocationsForJob(jobId: String): Future[WithId[immutable.Seq[Allocation]]]
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadHttpClient.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadHttpClient.scala
@@ -1,0 +1,34 @@
+package de.frosner.broccoli.nomad
+
+import de.frosner.broccoli.nomad.models.{Allocation, WithId}
+import play.api.libs.ws.{WSClient, WSRequest}
+
+import scala.collection.immutable
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * A client for the HTTP API of Nomad.
+  */
+class NomadHttpClient(baseUrl: String, client: WSClient)(implicit context: ExecutionContext) extends NomadClient {
+
+  /**
+    * Get allocations for a job.
+    *
+    * @param jobId The ID of the job
+    * @return The list of allocations for the job
+    */
+  override def getAllocationsForJob(jobId: String): Future[WithId[immutable.Seq[Allocation]]] =
+    for {
+      response <- url(s"job/$jobId/allocations")
+        .withHeaders("Accept" -> "application/json")
+        .get()
+    } yield WithId(jobId, response.json.as[immutable.Seq[Allocation]])
+
+  /**
+    * Build a web request with the given API path (without /v1/ prefix).
+    *
+    * @param apiPath The API path for API v1 (without /v1/ prefix)
+    * @return The corresponding web request.
+    */
+  private def url(apiPath: String): WSRequest = client.url(s"$baseUrl/v1/$apiPath")
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/Allocation.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/Allocation.scala
@@ -1,0 +1,21 @@
+package de.frosner.broccoli.nomad.models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+
+/**
+  * A partial model for a single allocations.
+  */
+final case class Allocation(id: String,
+                            nodeId: String,
+                            clientStatus: ClientStatus,
+                            taskStates: Map[String, TaskStateEvents])
+
+object Allocation {
+  implicit val allocationReads: Reads[Allocation] =
+    ((JsPath \ "ID").read[String] and
+      (JsPath \ "NodeID").read[String] and
+      (JsPath \ "ClientStatus").read[ClientStatus] and
+      (JsPath \ "TaskStates").readNullable[Map[String, TaskStateEvents]].map(_.getOrElse(Map.empty)))(
+      Allocation.apply _)
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/ClientStatus.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/ClientStatus.scala
@@ -1,0 +1,26 @@
+package de.frosner.broccoli.nomad.models
+
+import enumeratum._
+
+import scala.collection.immutable
+
+/**
+  * The nomad client status.
+  *
+  * Presumably this is the status the allocation
+  *
+  * See https://github.com/hashicorp/nomad/blob/2e7d8adfa4e9cbbc85009943f79641ac55875aa6/nomad/structs/structs.go#L4260
+  * for all possible values.
+  */
+sealed trait ClientStatus extends EnumEntry with EnumEntry.Lowercase
+
+object ClientStatus extends Enum[ClientStatus] with PlayJsonEnum[ClientStatus] {
+
+  override val values: immutable.IndexedSeq[ClientStatus] = findValues
+
+  case object Pending extends ClientStatus
+  case object Running extends ClientStatus
+  case object Complete extends ClientStatus
+  case object Failed extends ClientStatus
+  case object Lost extends ClientStatus
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskState.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskState.scala
@@ -1,0 +1,21 @@
+package de.frosner.broccoli.nomad.models
+
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
+
+import scala.collection.immutable
+
+/**
+  * The state of a single task.
+  *
+  * See https://github.com/hashicorp/nomad/blob/2e7d8adfa4e9cbbc85009943f79641ac55875aa6/nomad/structs/structs.go#L3367
+  * for the list of possible task states.
+  */
+sealed trait TaskState extends EnumEntry with EnumEntry.Lowercase
+
+object TaskState extends Enum[TaskState] with PlayJsonEnum[TaskState] {
+  override val values: immutable.IndexedSeq[TaskState] = findValues
+
+  case object Pending extends TaskState
+  case object Running extends TaskState
+  case object Dead extends TaskState
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskStateEvents.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskStateEvents.scala
@@ -1,0 +1,12 @@
+package de.frosner.broccoli.nomad.models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+
+final case class TaskStateEvents(state: TaskState)
+
+object TaskStateEvents {
+
+  implicit val taskStateEventsReads: Reads[TaskStateEvents] =
+    (JsPath \ "State").read[TaskState].map(TaskStateEvents(_))
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/WithId.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/WithId.scala
@@ -1,0 +1,10 @@
+package de.frosner.broccoli.nomad.models
+
+/**
+  * Attaches a nomad ID to arbitrary payload.
+  *
+  * @param jobId The nomad ID
+  * @param payload The payload
+  * @tparam T The type of the paylo
+  */
+final case class WithId[T](jobId: String, payload: T)

--- a/server/src/test/resources/de/frosner/broccoli/services/nomad/allocations.json
+++ b/server/src/test/resources/de/frosner/broccoli/services/nomad/allocations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ID": "520bc6c3-53c9-fd2e-5bea-7d0b9dbef254",
+    "EvalID": "2da4bad2-9047-f64f-07c9-456e3913dc5f",
+    "Name": "tvftarcxrPoy9wNhghqQogihjha.http-group[0]",
+    "NodeID": "cf3338e9-5ed0-88ef-df7b-9dd9708130c8",
+    "JobID": "tvftarcxrPoy9wNhghqQogihjha",
+    "TaskGroup": "http-group",
+    "DesiredStatus": "run",
+    "DesiredDescription": "",
+    "ClientStatus": "running",
+    "ClientDescription": "",
+    "TaskStates": {
+      "http-task": {
+        "State": "running",
+        "Events": [
+          {
+            "Type": "Received",
+            "Time": 1500896396933247233,
+            "RestartReason": "",
+            "DriverError": "",
+            "ExitCode": 0,
+            "Signal": 0,
+            "Message": "",
+            "KillError": "",
+            "StartDelay": 0,
+            "DownloadError": "",
+            "ValidationError": ""
+          },
+          {
+            "Type": "Started",
+            "Time": 1500896396967924930,
+            "RestartReason": "",
+            "DriverError": "",
+            "ExitCode": 0,
+            "Signal": 0,
+            "Message": "",
+            "KillError": "",
+            "StartDelay": 0,
+            "DownloadError": "",
+            "ValidationError": ""
+          }
+        ]
+      }
+    },
+    "CreateIndex": 8,
+    "ModifyIndex": 10,
+    "CreateTime": 1500896396923430455
+  }
+]

--- a/server/src/test/scala/de/frosner/broccoli/nomad/models/AllocationSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/nomad/models/AllocationSpec.scala
@@ -1,0 +1,26 @@
+package de.frosner.broccoli.nomad.models
+
+import de.frosner.broccoli.util.Resources
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+class AllocationSpec extends Specification {
+
+  "Allocation" should {
+
+    "decode from JSON" in {
+      val allocations = Json
+        .parse(Resources.readAsString("/de/frosner/broccoli/services/nomad/allocations.json"))
+        .validate[List[Allocation]]
+        .asEither
+
+      val allocation = Allocation(
+        id = "520bc6c3-53c9-fd2e-5bea-7d0b9dbef254",
+        nodeId = "cf3338e9-5ed0-88ef-df7b-9dd9708130c8",
+        clientStatus = ClientStatus.Running,
+        taskStates = Map("http-task" -> TaskStateEvents(TaskState.Running))
+      )
+      allocations should beRight(List(allocation))
+    }
+  }
+}

--- a/server/src/test/scala/de/frosner/broccoli/util/Resources.scala
+++ b/server/src/test/scala/de/frosner/broccoli/util/Resources.scala
@@ -1,0 +1,24 @@
+package de.frosner.broccoli.util
+
+import scala.io.Source
+
+/**
+  * Utilities for reading resources.
+  */
+object Resources {
+
+  /**
+    * Read a resource as string.
+    *
+    * @param path The resource path
+    * @return The resource string
+    */
+  def readAsString(path: String): String = {
+    val stream = getClass.getResourceAsStream(path)
+    try {
+      Source.fromInputStream(stream, "UTF-8").mkString
+    } finally {
+      stream.close()
+    }
+  }
+}


### PR DESCRIPTION
Runs integration tests for the Nomad client against the docker test image from specs2, i.e., adds infrastructure to gradually replace the bash-scripted integration tests.