### PR TITLE
Fix failing Docker build

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -5,13 +5,8 @@ RUN apt-get update && \
   apt-get install -y apt-transport-https ca-certificates && \
   apt-get clean all
 
-RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-  echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list && \
-  apt-get update && \
-  apt-get purge lxc-docker && \
-  apt-cache policy docker-engine && \
-  apt-get update && \
-  apt-get install -y docker-engine
+RUN curl -fsSL get.docker.com -o get-docker.sh
+RUN sh get-docker.sh
 
 # put nomad
 RUN curl https://releases.hashicorp.com/nomad/0.4.0/nomad_0.4.0_linux_amd64.zip > nomad.zip

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
   apt-get install -y apt-transport-https ca-certificates && \
   apt-get clean all
 
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
   echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list && \
   apt-get update && \
   apt-get purge lxc-docker && \


### PR DESCRIPTION
https://travis-ci.org/FRosner/cluster-broccoli/jobs/262126217

```
Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --homedir /tmp/tmp.qgDLXuk8pc --no-auto-check-trustdb --trust-model always --primary-keyring /etc/apt/trusted.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-security-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-stable.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-squeeze-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-squeeze-stable.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-wheezy-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-wheezy-stable.gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
gpg: keyserver timed out
gpg: keyserver receive failed: keyserver error
```