### PR TITLE
Send tasks over web sockets

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -6,6 +6,7 @@ play.crypto.secret="IN_PRODUCTION_CHANGE_THIS_TO_A_LONG_RANDOM_STRING"
 
 # Additional modules for our Broccoli
 play.modules.enabled += "de.frosner.broccoli.nomad.NomadModule"
+play.modules.enabled += "de.frosner.broccoli.websocket.WebSocketModule"
 play.modules.enabled += "de.frosner.broccoli.templates.TemplateModule"
 play.modules.enabled += "de.frosner.broccoli.signal.SignalModule"
 

--- a/server/src/main/scala/de/frosner/broccoli/controllers/IncomingWsMessage.scala
+++ b/server/src/main/scala/de/frosner/broccoli/controllers/IncomingWsMessage.scala
@@ -27,6 +27,7 @@ object IncomingWsMessage {
     case object AddInstance extends Type
     case object DeleteInstance extends Type
     case object UpdateInstance extends Type
+    case object GetInstanceTasks extends Type
   }
 
   /**
@@ -51,6 +52,13 @@ object IncomingWsMessage {
   final case class UpdateInstance(instance: InstanceUpdate) extends IncomingWsMessage
 
   /**
+    * Query the tasks of an instance.
+    *
+    * @param instance The ID of the instance
+    */
+  final case class GetInstanceTasks(instance: String) extends IncomingWsMessage
+
+  /**
     * JSON formats for a message incoming from a websocket.
     *
     * The JSON structure is not particularly straight-forward and deviates from what a generated Reads instance would
@@ -60,18 +68,20 @@ object IncomingWsMessage {
   implicit val incomingWsMessageFormat: Format[IncomingWsMessage] = Format.apply(
     (JsPath \ "messageType").read[Type].flatMap(readsPayload),
     Writes {
-      case AddInstance(create)      => write(Type.AddInstance, create)
-      case DeleteInstance(instance) => write(Type.DeleteInstance, instance)
-      case UpdateInstance(update)   => write(Type.UpdateInstance, update)
+      case AddInstance(create)        => write(Type.AddInstance, create)
+      case DeleteInstance(instance)   => write(Type.DeleteInstance, instance)
+      case UpdateInstance(update)     => write(Type.UpdateInstance, update)
+      case GetInstanceTasks(instance) => write(Type.GetInstanceTasks, instance)
     }
   )
 
   private def readsPayload(`type`: Type): Reads[IncomingWsMessage] = {
     val payload = JsPath \ "payload"
     `type` match {
-      case Type.AddInstance    => payload.read[InstanceCreation].map(AddInstance)
-      case Type.DeleteInstance => payload.read[String].map(DeleteInstance)
-      case Type.UpdateInstance => payload.read[InstanceUpdate].map(UpdateInstance)
+      case Type.AddInstance      => payload.read[InstanceCreation].map(AddInstance)
+      case Type.DeleteInstance   => payload.read[String].map(DeleteInstance)
+      case Type.UpdateInstance   => payload.read[InstanceUpdate].map(UpdateInstance)
+      case Type.GetInstanceTasks => payload.read[String].map(GetInstanceTasks)
     }
   }
 

--- a/server/src/main/scala/de/frosner/broccoli/controllers/OutgoingWsMessage.scala
+++ b/server/src/main/scala/de/frosner/broccoli/controllers/OutgoingWsMessage.scala
@@ -34,6 +34,8 @@ object OutgoingWsMessage {
     case object DeleteInstanceError extends Type
     case object UpdateInstanceSuccess extends Type
     case object UpdateInstanceError extends Type
+    case object GetInstanceTasksSuccess extends Type
+    case object GetInstanceTasksFailure extends Type
   }
 
   final case class ListTemplates(templates: Seq[Template]) extends OutgoingWsMessage
@@ -47,6 +49,8 @@ object OutgoingWsMessage {
   final case class DeleteInstanceError(error: InstanceError) extends OutgoingWsMessage
   final case class UpdateInstanceSuccess(result: InstanceUpdated) extends OutgoingWsMessage
   final case class UpdateInstanceError(error: InstanceError) extends OutgoingWsMessage
+  final case class GetInstanceTasksSuccess(tasks: InstanceTasks) extends OutgoingWsMessage
+  final case class GetInstanceTasksError(error: InstanceError) extends OutgoingWsMessage
 
   /**
     * JSON writes for a message outgoing to a websocket.
@@ -57,17 +61,19 @@ object OutgoingWsMessage {
     */
   implicit val outgoingWsMessageWrites: Writes[OutgoingWsMessage] =
     Writes {
-      case ListTemplates(templates)      => write(Type.ListTemplates, templates)
-      case ListInstances(instances)      => write(Type.ListInstances, instances)
-      case AboutInfoMsg(info)            => write(Type.AboutInfo, info)
-      case Error(error)                  => write(Type.Error, error)
-      case Notification(message)         => write(Type.Notification, message)
-      case AddInstanceSuccess(result)    => write(Type.AddInstanceSuccess, result)
-      case AddInstanceError(result)      => write(Type.AddInstanceError, result)
-      case DeleteInstanceSuccess(result) => write(Type.DeleteInstanceSuccess, result)
-      case DeleteInstanceError(result)   => write(Type.DeleteInstanceError, result)
-      case UpdateInstanceSuccess(result) => write(Type.UpdateInstanceSuccess, result)
-      case UpdateInstanceError(result)   => write(Type.UpdateInstanceError, result)
+      case ListTemplates(templates)        => write(Type.ListTemplates, templates)
+      case ListInstances(instances)        => write(Type.ListInstances, instances)
+      case AboutInfoMsg(info)              => write(Type.AboutInfo, info)
+      case Error(error)                    => write(Type.Error, error)
+      case Notification(message)           => write(Type.Notification, message)
+      case AddInstanceSuccess(result)      => write(Type.AddInstanceSuccess, result)
+      case AddInstanceError(error)         => write(Type.AddInstanceError, error)
+      case DeleteInstanceSuccess(result)   => write(Type.DeleteInstanceSuccess, result)
+      case DeleteInstanceError(error)      => write(Type.DeleteInstanceError, error)
+      case UpdateInstanceSuccess(result)   => write(Type.UpdateInstanceSuccess, result)
+      case UpdateInstanceError(error)      => write(Type.UpdateInstanceError, error)
+      case GetInstanceTasksSuccess(result) => write(Type.GetInstanceTasksSuccess, result)
+      case GetInstanceTasksError(error)    => write(Type.GetInstanceTasksFailure, error)
     }
 
   private def write[P](`type`: Type, payload: P)(implicit writesP: Writes[P]): JsObject =

--- a/server/src/main/scala/de/frosner/broccoli/controllers/WebSocketController.scala
+++ b/server/src/main/scala/de/frosner/broccoli/controllers/WebSocketController.scala
@@ -2,18 +2,15 @@ package de.frosner.broccoli.controllers
 
 import javax.inject.Inject
 
-import cats.data.EitherT
-import cats.syntax.either._
-import cats.instances.future._
-import de.frosner.broccoli.controllers.OutgoingWsMessage._
 import de.frosner.broccoli.services.WebSocketService.Msg
 import de.frosner.broccoli.services._
 import de.frosner.broccoli.util.Logging
+import de.frosner.broccoli.websocket.{IncomingMessage, OutgoingMessage, WebSocketMessageHandler}
 import jp.t2v.lab.play2.auth.BroccoliWebsocketSecurity
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.iteratee._
 import play.api.libs.json._
 import play.api.mvc._
-import play.api.libs.concurrent.Execution.Implicits._
 
 import scala.concurrent.Future
 
@@ -21,6 +18,7 @@ case class WebSocketController @Inject()(webSocketService: WebSocketService,
                                          templateService: TemplateService,
                                          instanceService: InstanceService,
                                          aboutService: AboutInfoService,
+                                         messageHandler: WebSocketMessageHandler,
                                          override val securityService: SecurityService)
     extends Controller
     with Logging
@@ -39,54 +37,29 @@ case class WebSocketController @Inject()(webSocketService: WebSocketService,
       // TODO receive string and try json decoding here because I can handle the error better
       val in = Enumeratee.mapM[Msg] { incomingMessage =>
         Json
-          .fromJson[IncomingWsMessage](incomingMessage)
-          // We return a future here, since some messages map to asynchronous operations.
-          .map[Future[OutgoingWsMessage]] {
-            case IncomingWsMessage.AddInstance(instanceCreation) =>
-              InstanceController
-                .create(instanceCreation, user, instanceService)
-                // We lift the plain Either returned by ".create" into an EitherT and thus into a "Future", so that the
-                // subsequent ".fold" gives us not just an OutgoingWsMessage, but a Future[OutgoingWsMessage]
-                .toEitherT
-                .fold(AddInstanceError, AddInstanceSuccess)
-            case IncomingWsMessage.DeleteInstance(instanceId) =>
-              InstanceController
-                .delete(instanceId, user, instanceService)
-                .toEitherT
-                .fold(DeleteInstanceError, DeleteInstanceSuccess)
-            case IncomingWsMessage.UpdateInstance(instanceUpdate) =>
-              InstanceController
-                .update(instanceUpdate.instanceId.get, instanceUpdate, user, instanceService)
-                .toEitherT
-                .fold(UpdateInstanceError, UpdateInstanceSuccess)
-            case IncomingWsMessage.GetInstanceTasks(instanceId) =>
-              instanceService
-                .getInstanceTasks(user)(instanceId)
-                .fold(GetInstanceTasksError, GetInstanceTasksSuccess)
-          }
+          .fromJson[IncomingMessage](incomingMessage)
+          .map(messageHandler.processMessage(user))
           .recoverTotal { error =>
             Logger.warn(s"Can't parse a message from $connectionId: $error")
-            Future.successful(OutgoingWsMessage.Error(s"Failed to parse message message: $error"))
+            Future.successful(OutgoingMessage.Error(s"Failed to parse message message: $error"))
           }
       } transform Iteratee
-        .foreach { outgoingMessage: OutgoingWsMessage =>
-          webSocketService.send(connectionId, Json.toJson(outgoingMessage))
-        }
+        .foreach[OutgoingMessage](msg => webSocketService.send(connectionId, Json.toJson(msg)))
         .map { _ =>
           webSocketService.closeConnections(connectionId)
           Logger.info(s"Closed connection $connectionLogString")
         }
 
       val aboutEnumerator =
-        Enumerator[Msg](Json.toJson(OutgoingWsMessage.AboutInfoMsg(AboutController.about(aboutService, user))))
+        Enumerator[Msg](Json.toJson(OutgoingMessage.AboutInfoMsg(AboutController.about(aboutService, user))))
 
       val templateEnumerator = Enumerator[Msg](
         Json.toJson(
-          OutgoingWsMessage.ListTemplates(TemplateController.list(templateService))
+          OutgoingMessage.ListTemplates(TemplateController.list(templateService))
         ))
 
       val instanceEnumerator = Enumerator[Msg](
-        Json.toJson(OutgoingWsMessage.ListInstances(InstanceController.list(None, user, instanceService))))
+        Json.toJson(OutgoingMessage.ListInstances(InstanceController.list(None, user, instanceService))))
       (in, aboutEnumerator.andThen(templateEnumerator).andThen(instanceEnumerator).andThen(connectionEnumerator))
     }
 

--- a/server/src/main/scala/de/frosner/broccoli/models/InstanceTasks.scala
+++ b/server/src/main/scala/de/frosner/broccoli/models/InstanceTasks.scala
@@ -1,0 +1,15 @@
+package de.frosner.broccoli.models
+
+import play.api.libs.json.{Json, Writes}
+
+/**
+  * The tasks of an instance.
+  *
+  * @param instanceId The ID of the instance
+  * @param tasks The tasks of the instance
+  */
+final case class InstanceTasks(instanceId: String, tasks: Seq[Task])
+
+object InstanceTasks {
+  implicit val instanceTasksWrites: Writes[InstanceTasks] = Json.writes[InstanceTasks]
+}

--- a/server/src/main/scala/de/frosner/broccoli/models/Task.scala
+++ b/server/src/main/scala/de/frosner/broccoli/models/Task.scala
@@ -1,0 +1,29 @@
+package de.frosner.broccoli.models
+
+import de.frosner.broccoli.nomad.models.{ClientStatus, TaskState}
+import play.api.libs.json.{Json, Writes}
+
+/**
+  * A task and the allocations it runs on.
+  *
+  * @param name The name of the task
+  * @param allocations The allocations this task runs on
+  */
+final case class Task(name: String, allocations: Seq[Task.Allocation])
+
+object Task {
+  implicit val taskWrites: Writes[Task] = Json.writes[Task]
+
+  /**
+    * A single allocation for a Task
+    *
+    * @param id The ID of the allocation
+    * @param clientStatus The client (=instance) status of this allocation
+    * @param taskState The state of the task in this allocation
+    */
+  final case class Allocation(id: String, clientStatus: ClientStatus, taskState: TaskState)
+
+  object Allocation {
+    implicit val allocationWrites: Writes[Allocation] = Json.writes[Allocation]
+  }
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadModule.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadModule.scala
@@ -23,4 +23,19 @@ class NomadModule extends AbstractModule with ScalaModule {
   @Singleton
   def provideNomadConfiguration(config: Configuration): NomadConfiguration =
     NomadConfiguration.fromConfig(config.underlying.getConfig("broccoli.nomad"))
+
+  /**
+    * Provide a nomad client.
+    *
+    * The nomad client provided by this method uses Play's client so we let it run on Play's default execution context.
+    * Play's web service client does not block.
+    *
+    * @param config The nomad configuration
+    * @param wsClient The play web service client to use
+    * @return A HTTP client for Nomad
+    */
+  @Provides
+  @Singleton
+  def provideNomadClient(config: NomadConfiguration, wsClient: WSClient): NomadClient =
+    new NomadHttpClient(config.url, wsClient)(play.api.libs.concurrent.Execution.defaultContext)
 }

--- a/server/src/main/scala/de/frosner/broccoli/services/InstanceService.scala
+++ b/server/src/main/scala/de/frosner/broccoli/services/InstanceService.scala
@@ -5,20 +5,24 @@ import java.net.ConnectException
 import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
 import javax.inject.{Inject, Singleton}
 
-import de.frosner.broccoli.models._
+import cats.data.EitherT
+import cats.instances.future._
+import de.frosner.broccoli.conf
 import de.frosner.broccoli.models.JobStatus.JobStatus
+import de.frosner.broccoli.models._
+import de.frosner.broccoli.nomad.NomadClient
 import de.frosner.broccoli.util.Logging
 import play.api.Configuration
+import play.api.inject.ApplicationLifecycle
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.ws.WSClient
 
-import scala.util.{Failure, Success, Try}
-import de.frosner.broccoli.conf
-import play.api.inject.ApplicationLifecycle
-
 import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
 
 @Singleton
-class InstanceService @Inject()(templateService: TemplateService,
+class InstanceService @Inject()(nomadClient: NomadClient,
+                                templateService: TemplateService,
                                 nomadService: NomadService,
                                 consulService: ConsulService,
                                 ws: WSClient,
@@ -164,8 +168,6 @@ class InstanceService @Inject()(templateService: TemplateService,
     )
   }
 
-  implicit val executionContext = play.api.libs.concurrent.Execution.Implicits.defaultContext
-
   def getInstances: Seq[InstanceWithStatus] =
     instances.values.map(addStatuses).toSeq
 
@@ -306,4 +308,40 @@ class InstanceService @Inject()(templateService: TemplateService,
     tryDelete.map(addStatuses)
   }
 
+  /**
+    * Get all tasks of the given instance.
+    *
+    * In Nomad the hierarchy is normally "allocation -> tasks in that allocation".  However allocations have generic
+    * UUID whereas tasks have human-readable names, so we believe that tasks are easier as an "entry point" for the user
+    * in the UI.  Hence this method inverts the hierarchy of models returned by Nomad.
+    *
+    * @param user The user requesting tasks for the instance, for access control
+    * @param id The instance ID
+    * @return All tasks of the given instance with their allocations, or an empty list if the instance has no tasks or
+    *         didn't exist.  If the user may not access the instance return an InstanceError instead.
+    */
+  def getInstanceTasks(user: Account)(id: String): EitherT[Future, InstanceError, InstanceTasks] =
+    EitherT
+      .pure[Future, InstanceError](id)
+      .ensureOr(InstanceError.UserRegexDenied(_, user.instanceRegex))(_.matches(user.instanceRegex))
+      .semiflatMap(nomadClient.getAllocationsForJob)
+      .map { allocations =>
+        InstanceTasks(
+          id,
+          // Invert the order "allocation -> task" into "task -> allocation" (see doc comment)
+          allocations.payload
+            .flatMap(allocation => allocation.taskStates.mapValues(_ -> allocation))
+            .groupBy {
+              case (taskName, _) => taskName
+            }
+            .map {
+              case (taskId, items) =>
+                Task(taskId, items.map {
+                  case (_, (events, allocation)) =>
+                    Task.Allocation(allocation.id, allocation.clientStatus, events.state)
+                })
+            }
+            .toSeq
+        )
+      }
 }

--- a/server/src/main/scala/de/frosner/broccoli/services/WebSocketService.scala
+++ b/server/src/main/scala/de/frosner/broccoli/services/WebSocketService.scala
@@ -8,6 +8,7 @@ import de.frosner.broccoli.controllers._
 import de.frosner.broccoli.models.{Account, Anonymous}
 import de.frosner.broccoli.services.WebSocketService.Msg
 import de.frosner.broccoli.util.Logging
+import de.frosner.broccoli.websocket.OutgoingMessage
 import play.api.Configuration
 import play.api.libs.iteratee.{Concurrent, Enumerator}
 import play.api.libs.json.{JsValue, Json}
@@ -25,13 +26,13 @@ class WebSocketService @Inject()(templateService: TemplateService,
   private val task = new Runnable {
     def run() = {
       broadcast { user =>
-        Json.toJson(OutgoingWsMessage.AboutInfoMsg(AboutController.about(aboutInfoService, user)))
+        Json.toJson(OutgoingMessage.AboutInfoMsg(AboutController.about(aboutInfoService, user)))
       }
       broadcast { _ =>
-        Json.toJson(OutgoingWsMessage.ListTemplates(TemplateController.list(templateService)))
+        Json.toJson(OutgoingMessage.ListTemplates(TemplateController.list(templateService)))
       }
       broadcast { user =>
-        Json.toJson(OutgoingWsMessage.ListInstances(InstanceController.list(None, user, instanceService)))
+        Json.toJson(OutgoingMessage.ListInstances(InstanceController.list(None, user, instanceService)))
       }
     }
   }

--- a/server/src/main/scala/de/frosner/broccoli/websocket/IncomingMessage.scala
+++ b/server/src/main/scala/de/frosner/broccoli/websocket/IncomingMessage.scala
@@ -1,17 +1,17 @@
-package de.frosner.broccoli.controllers
+package de.frosner.broccoli.websocket
 
 import de.frosner.broccoli.models._
-import play.api.libs.json._
 import enumeratum._
+import play.api.libs.json._
 
 import scala.collection.immutable
 
 /**
   * An incoming message on Broccoli's web socket connection.
   */
-sealed trait IncomingWsMessage
+sealed trait IncomingMessage
 
-object IncomingWsMessage {
+object IncomingMessage {
 
   /**
     * The type of an incoming message on the web socket.
@@ -35,28 +35,28 @@ object IncomingWsMessage {
     *
     * @param instance A description of the instance to add.
     */
-  final case class AddInstance(instance: InstanceCreation) extends IncomingWsMessage
+  final case class AddInstance(instance: InstanceCreation) extends IncomingMessage
 
   /**
     * Delete an instance.
     *
     * @param instance The name of the instance to delete
     */
-  final case class DeleteInstance(instance: String) extends IncomingWsMessage
+  final case class DeleteInstance(instance: String) extends IncomingMessage
 
   /**
     * Update an instance.
     *
     * @param instance A description of the instance to update
     */
-  final case class UpdateInstance(instance: InstanceUpdate) extends IncomingWsMessage
+  final case class UpdateInstance(instance: InstanceUpdate) extends IncomingMessage
 
   /**
     * Query the tasks of an instance.
     *
     * @param instance The ID of the instance
     */
-  final case class GetInstanceTasks(instance: String) extends IncomingWsMessage
+  final case class GetInstanceTasks(instance: String) extends IncomingMessage
 
   /**
     * JSON formats for a message incoming from a websocket.
@@ -65,7 +65,7 @@ object IncomingWsMessage {
     * deserialize.  However, it maintains compatibility with the earlier implementation of IncomingWsMessage that used
     * a dedicated "type" enum and an unsafe object-typed payload.
     */
-  implicit val incomingWsMessageFormat: Format[IncomingWsMessage] = Format.apply(
+  implicit val incomingMessageFormat: Format[IncomingMessage] = Format.apply(
     (JsPath \ "messageType").read[Type].flatMap(readsPayload),
     Writes {
       case AddInstance(create)        => write(Type.AddInstance, create)
@@ -75,7 +75,7 @@ object IncomingWsMessage {
     }
   )
 
-  private def readsPayload(`type`: Type): Reads[IncomingWsMessage] = {
+  private def readsPayload(`type`: Type): Reads[IncomingMessage] = {
     val payload = JsPath \ "payload"
     `type` match {
       case Type.AddInstance      => payload.read[InstanceCreation].map(AddInstance)

--- a/server/src/main/scala/de/frosner/broccoli/websocket/OutgoingMessage.scala
+++ b/server/src/main/scala/de/frosner/broccoli/websocket/OutgoingMessage.scala
@@ -1,16 +1,15 @@
-package de.frosner.broccoli.controllers
+package de.frosner.broccoli.websocket
 
-import de.frosner.broccoli.models._
 import de.frosner.broccoli.models.Template.templateApiWrites
-import enumeratum.EnumEntry.Camelcase
-import play.api.libs.json._
+import de.frosner.broccoli.models._
 import enumeratum._
+import play.api.libs.json._
 
 import scala.collection.immutable
 
-sealed trait OutgoingWsMessage
+sealed trait OutgoingMessage
 
-object OutgoingWsMessage {
+object OutgoingMessage {
 
   /**
     * The type of an outgoing message on the web socket.
@@ -38,19 +37,19 @@ object OutgoingWsMessage {
     case object GetInstanceTasksFailure extends Type
   }
 
-  final case class ListTemplates(templates: Seq[Template]) extends OutgoingWsMessage
-  final case class ListInstances(instances: Seq[InstanceWithStatus]) extends OutgoingWsMessage
-  final case class AboutInfoMsg(info: AboutInfo) extends OutgoingWsMessage
-  final case class Error(error: String) extends OutgoingWsMessage
-  final case class Notification(message: String) extends OutgoingWsMessage
-  final case class AddInstanceSuccess(result: InstanceCreated) extends OutgoingWsMessage
-  final case class AddInstanceError(error: InstanceError) extends OutgoingWsMessage
-  final case class DeleteInstanceSuccess(result: InstanceDeleted) extends OutgoingWsMessage
-  final case class DeleteInstanceError(error: InstanceError) extends OutgoingWsMessage
-  final case class UpdateInstanceSuccess(result: InstanceUpdated) extends OutgoingWsMessage
-  final case class UpdateInstanceError(error: InstanceError) extends OutgoingWsMessage
-  final case class GetInstanceTasksSuccess(tasks: InstanceTasks) extends OutgoingWsMessage
-  final case class GetInstanceTasksError(error: InstanceError) extends OutgoingWsMessage
+  final case class ListTemplates(templates: Seq[Template]) extends OutgoingMessage
+  final case class ListInstances(instances: Seq[InstanceWithStatus]) extends OutgoingMessage
+  final case class AboutInfoMsg(info: AboutInfo) extends OutgoingMessage
+  final case class Error(error: String) extends OutgoingMessage
+  final case class Notification(message: String) extends OutgoingMessage
+  final case class AddInstanceSuccess(result: InstanceCreated) extends OutgoingMessage
+  final case class AddInstanceError(error: InstanceError) extends OutgoingMessage
+  final case class DeleteInstanceSuccess(result: InstanceDeleted) extends OutgoingMessage
+  final case class DeleteInstanceError(error: InstanceError) extends OutgoingMessage
+  final case class UpdateInstanceSuccess(result: InstanceUpdated) extends OutgoingMessage
+  final case class UpdateInstanceError(error: InstanceError) extends OutgoingMessage
+  final case class GetInstanceTasksSuccess(tasks: InstanceTasks) extends OutgoingMessage
+  final case class GetInstanceTasksError(error: InstanceError) extends OutgoingMessage
 
   /**
     * JSON writes for a message outgoing to a websocket.
@@ -59,7 +58,7 @@ object OutgoingWsMessage {
     * deserialize.  However, it maintains compatibility with the earlier implementation of OutgoingWsMessage that used
     * a dedicated "type" enum and an unsafe any-typed payload.
     */
-  implicit val outgoingWsMessageWrites: Writes[OutgoingWsMessage] =
+  implicit val outgoingMessageWrites: Writes[OutgoingMessage] =
     Writes {
       case ListTemplates(templates)        => write(Type.ListTemplates, templates)
       case ListInstances(instances)        => write(Type.ListInstances, instances)

--- a/server/src/main/scala/de/frosner/broccoli/websocket/WebSocketMessageHandler.scala
+++ b/server/src/main/scala/de/frosner/broccoli/websocket/WebSocketMessageHandler.scala
@@ -1,0 +1,58 @@
+package de.frosner.broccoli.websocket
+
+import javax.inject.Inject
+
+import cats.syntax.either._
+import cats.instances.future._
+import de.frosner.broccoli.controllers.InstanceController
+import de.frosner.broccoli.models.Account
+import de.frosner.broccoli.services.InstanceService
+import de.frosner.broccoli.websocket.OutgoingMessage._
+import de.frosner.broccoli.websocket.IncomingMessage._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Process websocket messages.
+  */
+trait WebSocketMessageHandler {
+
+  /**
+    * Process an incoming websocket message.
+    *
+    * @param user The user who's sending the messages
+    * @param incomingMessage An incoming message
+    * @return An outgoing message to send in response
+    */
+  def processMessage(user: Account)(incomingMessage: IncomingMessage): Future[OutgoingMessage]
+}
+
+/**
+  * Process broccoli's websocket messages.
+  */
+class BroccoliMessageHandler @Inject()(instanceService: InstanceService)(implicit ec: ExecutionContext)
+    extends WebSocketMessageHandler {
+
+  override def processMessage(user: Account)(incomingMessage: IncomingMessage): Future[OutgoingMessage] =
+    incomingMessage match {
+      case AddInstance(instanceCreation) =>
+        InstanceController
+          .create(instanceCreation, user, instanceService)
+          .toEitherT
+          .fold(AddInstanceError, AddInstanceSuccess)
+      case DeleteInstance(instanceId) =>
+        InstanceController
+          .delete(instanceId, user, instanceService)
+          .toEitherT
+          .fold(DeleteInstanceError, DeleteInstanceSuccess)
+      case UpdateInstance(instanceUpdate) =>
+        InstanceController
+          .update(instanceUpdate.instanceId.get, instanceUpdate, user, instanceService)
+          .toEitherT
+          .fold(UpdateInstanceError, UpdateInstanceSuccess)
+      case GetInstanceTasks(instanceId) =>
+        instanceService
+          .getInstanceTasks(user)(instanceId)
+          .fold(GetInstanceTasksError, GetInstanceTasksSuccess)
+    }
+}

--- a/server/src/main/scala/de/frosner/broccoli/websocket/WebSocketModule.scala
+++ b/server/src/main/scala/de/frosner/broccoli/websocket/WebSocketModule.scala
@@ -1,0 +1,13 @@
+package de.frosner.broccoli.websocket
+
+import com.google.inject.AbstractModule
+import net.codingwell.scalaguice.ScalaModule
+
+/**
+  * Configure websockets for Broccoli.
+  */
+class WebSocketModule extends AbstractModule with ScalaModule {
+  override def configure(): Unit =
+    bind[WebSocketMessageHandler].to[BroccoliMessageHandler]
+
+}

--- a/server/src/test/scala/de/frosner/broccoli/nomad/ModelArbitraries.scala
+++ b/server/src/test/scala/de/frosner/broccoli/nomad/ModelArbitraries.scala
@@ -1,0 +1,18 @@
+package de.frosner.broccoli.nomad
+
+import de.frosner.broccoli.nomad.models._
+import org.scalacheck.{Arbitrary, Gen}
+
+/**
+  * Arbitrary instances for Nomad models.
+  */
+trait ModelArbitraries {
+  implicit val arbitraryClientStatus: Arbitrary[ClientStatus] = Arbitrary(Gen.oneOf(ClientStatus.values))
+
+  implicit val arbitraryTaskState: Arbitrary[TaskState] = Arbitrary(Gen.oneOf(TaskState.values))
+}
+
+/**
+  * Import object for Nomad arbitraries.
+  */
+object arbitraries extends ModelArbitraries

--- a/server/src/test/scala/de/frosner/broccoli/websocket/BroccoliMessageHandlerSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/websocket/BroccoliMessageHandlerSpec.scala
@@ -1,0 +1,50 @@
+package de.frosner.broccoli.websocket
+
+import cats.data.EitherT
+import cats.instances.future._
+import de.frosner.broccoli.models._
+import de.frosner.broccoli.services.InstanceService
+import de.frosner.broccoli.nomad
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2.ScalaCheck
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.ExecutionEnvironment
+
+import scala.concurrent.Future
+
+class BroccoliMessageHandlerSpec
+    extends Specification
+    with ScalaCheck
+    with Mockito
+    with nomad.ModelArbitraries
+    with ModelArbitraries {
+
+  "The Broccoli Message Handler" should {
+    "send back instance tasks" in { implicit ee: ExecutionEnv =>
+      prop { (account: Account, id: String, tasks: List[Task]) =>
+        val service = mock[InstanceService]
+        val instanceTasks = InstanceTasks(id, tasks)
+        service.getInstanceTasks(account)(id) returns EitherT.pure[Future, InstanceError](instanceTasks)
+
+        val outgoingMessage = new BroccoliMessageHandler(service)
+          .processMessage(account)(IncomingMessage.GetInstanceTasks(id))
+
+        outgoingMessage must beEqualTo(OutgoingMessage.GetInstanceTasksSuccess(instanceTasks)).await
+      }.setGen2(Gen.identifier)
+    }
+
+    "send back an error if instance tasks failed" in { implicit ee: ExecutionEnv =>
+      prop { (account: Account, id: String, error: InstanceError) =>
+        val service = mock[InstanceService]
+        service.getInstanceTasks(account)(id) returns EitherT.leftT[Future, InstanceTasks](error)
+
+        val outgoingMessage = new BroccoliMessageHandler(service)
+          .processMessage(account)(IncomingMessage.GetInstanceTasks(id))
+
+        outgoingMessage must beEqualTo(OutgoingMessage.GetInstanceTasksError(error)).await
+      }.setGen2(Gen.identifier)
+    }
+  }
+}

--- a/webui/src/Messages.elm
+++ b/webui/src/Messages.elm
@@ -13,6 +13,7 @@ import Models.Resources.Template exposing (Template)
 import Models.Resources.InstanceCreated exposing (InstanceCreated)
 import Models.Resources.InstanceDeleted exposing (InstanceDeleted)
 import Models.Resources.InstanceUpdated exposing (InstanceUpdated)
+import Models.Resources.InstanceTasks exposing (InstanceTasks)
 
 
 type AnyMsg
@@ -49,6 +50,8 @@ type IncomingWsMessage
     | DeleteInstanceErrorMessage InstanceError
     | UpdateInstanceSuccessMessage InstanceUpdated
     | UpdateInstanceErrorMessage InstanceError
+    | GetInstanceTasksSuccessMessage InstanceTasks
+    | GetInstanceTasksErrorMessage InstanceError
     | ErrorMessage String
 
 
@@ -58,3 +61,4 @@ type OutgoingWsMessage
     = AddInstanceMessage InstanceCreation
     | DeleteInstanceMessage InstanceId
     | UpdateInstanceMessage InstanceUpdate
+    | GetInstanceTasks InstanceId

--- a/webui/src/Model.elm
+++ b/webui/src/Model.elm
@@ -3,11 +3,11 @@ module Model exposing (Model, Route(..), initial)
 import Models.Resources.Template exposing (Template, TemplateId)
 import Models.Resources.Instance exposing (Instance, InstanceId)
 import Models.Resources.AboutInfo exposing (AboutInfo)
+import Models.Resources.Task exposing (Task)
 import Models.Ui.BodyUiModel as BodyUiModel exposing (BodyUiModel)
 import Models.Ui.LoginForm as LoginForm exposing (LoginForm)
 import Models.Ui.Notifications exposing (Errors)
 import Navigation exposing (Location)
-import Regex exposing (Regex)
 import Dict exposing (Dict)
 
 
@@ -15,12 +15,18 @@ type Route
     = MainRoute
 
 
+{-| The application state model
+
+This model holds the entire state of the whole application.
+
+-}
 type alias Model =
     { aboutInfo : Maybe AboutInfo
     , errors : Errors
     , loginForm : LoginForm
     , authRequired : Maybe Bool
     , instances : Dict InstanceId Instance
+    , tasks : Dict InstanceId (List Task)
     , templates : Dict TemplateId Template
     , bodyUiModel : BodyUiModel
     , wsConnected : Bool
@@ -31,6 +37,8 @@ type alias Model =
     }
 
 
+{-| Initial mostly empty values for the application state
+-}
 initial : Location -> Route -> Model
 initial location route =
     { aboutInfo = Nothing
@@ -39,6 +47,7 @@ initial location route =
     , authRequired = Nothing
     , bodyUiModel = BodyUiModel.initialModel
     , templates = Dict.empty
+    , tasks = Dict.empty
     , instances = Dict.empty
     , wsConnected = False
     , route = route

--- a/webui/src/Models/Resources/Allocation.elm
+++ b/webui/src/Models/Resources/Allocation.elm
@@ -1,0 +1,30 @@
+module Models.Resources.Allocation exposing (..)
+
+import Json.Decode as Decode exposing (field)
+import Models.Resources.TaskState as TaskState exposing (TaskState)
+import Models.Resources.ClientStatus as ClientStatus exposing (ClientStatus)
+
+
+{-| The type for the ID of an allocation.
+-}
+type alias AllocationId =
+    String
+
+
+{-| An allocation of a task with a state.
+-}
+type alias Allocation =
+    { id : AllocationId
+    , clientStatus : ClientStatus
+    , taskState : TaskState
+    }
+
+
+{-| Decode an allocation from JSON.
+-}
+decoder : Decode.Decoder Allocation
+decoder =
+    Decode.map3 Allocation
+        (field "id" Decode.string)
+        (field "clientStatus" ClientStatus.decoder)
+        (field "taskState" TaskState.decoder)

--- a/webui/src/Models/Resources/ClientStatus.elm
+++ b/webui/src/Models/Resources/ClientStatus.elm
@@ -1,0 +1,41 @@
+module Models.Resources.ClientStatus exposing (..)
+
+import Json.Decode exposing (Decoder, string, fail, succeed, andThen)
+
+
+{-| The status of the client of an allocation.
+-}
+type ClientStatus
+    = ClientPending
+    | ClientRunning
+    | ClientComplete
+    | ClientFailed
+    | ClientLost
+
+
+{-| Decode a client status from JSON.
+-}
+decoder : Decoder ClientStatus
+decoder =
+    string
+        |> andThen
+            (\name ->
+                case name of
+                    "pending" ->
+                        succeed ClientPending
+
+                    "running" ->
+                        succeed ClientRunning
+
+                    "complete" ->
+                        succeed ClientComplete
+
+                    "failed" ->
+                        succeed ClientFailed
+
+                    "lost" ->
+                        succeed ClientLost
+
+                    _ ->
+                        fail ("Unknown client status " ++ name)
+            )

--- a/webui/src/Models/Resources/InstanceTasks.elm
+++ b/webui/src/Models/Resources/InstanceTasks.elm
@@ -1,0 +1,22 @@
+module Models.Resources.InstanceTasks exposing (..)
+
+import Models.Resources.Instance exposing (InstanceId)
+import Models.Resources.Task as Task exposing (Task)
+import Json.Decode exposing (Decoder, string, field, map2, list)
+
+
+{-| The tasks of an instance
+-}
+type alias InstanceTasks =
+    { instanceId : InstanceId
+    , tasks : List Task
+    }
+
+
+{-| Decode tasks of an instance from JSON.
+-}
+decoder : Decoder InstanceTasks
+decoder =
+    map2 InstanceTasks
+        (field "instanceId" string)
+        (field "tasks" (list Task.decoder))

--- a/webui/src/Models/Resources/Task.elm
+++ b/webui/src/Models/Resources/Task.elm
@@ -1,0 +1,27 @@
+module Models.Resources.Task exposing (..)
+
+import Json.Decode as Decode exposing (field, list, string)
+import Models.Resources.Allocation as Allocation exposing (Allocation)
+
+
+{-| A type for the name of a task
+-}
+type alias TaskName =
+    String
+
+
+{-| A task with a name and the list of its allocations.
+-}
+type alias Task =
+    { name : TaskName
+    , allocations : List Allocation
+    }
+
+
+{-| Decode an allocation from JSON.
+-}
+decoder : Decode.Decoder Task
+decoder =
+    Decode.map2 Task
+        (field "name" string)
+        (field "allocations" (list Allocation.decoder))

--- a/webui/src/Models/Resources/TaskState.elm
+++ b/webui/src/Models/Resources/TaskState.elm
@@ -1,0 +1,33 @@
+module Models.Resources.TaskState exposing (..)
+
+import Json.Decode exposing (Decoder, string, fail, succeed, andThen)
+
+
+{-| The state of a task within an allocation.
+-}
+type TaskState
+    = TaskDead
+    | TaskRunning
+    | TaskPending
+
+
+{-| Decode a task state from JSON.
+-}
+decoder : Decoder TaskState
+decoder =
+    string
+        |> andThen
+            (\name ->
+                case name of
+                    "dead" ->
+                        succeed TaskDead
+
+                    "running" ->
+                        succeed TaskRunning
+
+                    "pending" ->
+                        succeed TaskPending
+
+                    _ ->
+                        fail ("Unknown task state " ++ name)
+            )


### PR DESCRIPTION
* Add websocket messages for instance tasks to server and web
* Turn processing of incoming messages into an Enumeratee flow over Future.  The server retrieves instance tasks asynchronously, so use an Enumeratee mapping over a `Future` to define the Iteratee for incoming messages.
* Move dispatching of messages, ie, mapping incoming to outgoing messages, into a separate component to tear apart different responsibilities and make processing testable without elaborate websocket setup.