### PR TITLE
WIP: Download nomad logs from webui

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val server = project
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= List(
       Dependencies.simulacrum,
+      Dependencies.shapeless,
       Dependencies.scalaguice,
       ws,
       cache,

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val server = project
     libraryDependencies ++= List(
       Dependencies.simulacrum,
       Dependencies.shapeless,
+      Dependencies.scalaUri,
       Dependencies.scalaguice,
       ws,
       cache,

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val server = project
       Dependencies.simulacrum,
       Dependencies.shapeless,
       Dependencies.scalaUri,
+      Dependencies.squants,
       Dependencies.scalaguice,
       ws,
       cache,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,8 @@ object Dependencies {
     val shapeless = "2.3.2"
 
     val scalaUri = "0.4.17"
+
+    val squants = "1.3.0"
   }
 
   /**
@@ -49,6 +51,13 @@ object Dependencies {
     * Types and DSL for URIs
     */
   val scalaUri: ModuleID = "io.lemonlabs" %% "scala-uri" % Versions.scalaUri
+
+  /**
+    * Units for Scala.
+    *
+    * We use it for size units, eg bytes, kilobytes, etc.
+    */
+  val squants: ModuleID = "org.typelevel" %% "squants" % Versions.squants
 
   /**
     * Property testing for Scala.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,8 @@ object Dependencies {
     val play2auth = "0.14.2"
 
     val cats = "1.0.0-MF"
+
+    val shapeless = "2.3.2"
   }
 
   /**
@@ -26,6 +28,11 @@ object Dependencies {
     "kernel",
     "core"
   ).map(module => "org.typelevel" %% s"cats-$module" % Versions.cats)
+
+  /**
+    * Type-level programming library
+    */
+  val shapeless: ModuleID = "com.chuusai" %% "shapeless" % Versions.shapeless
 
   /**
     * A powerful enumeration type for Scala.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,8 @@ object Dependencies {
     val cats = "1.0.0-MF"
 
     val shapeless = "2.3.2"
+
+    val scalaUri = "0.4.17"
   }
 
   /**
@@ -42,6 +44,11 @@ object Dependencies {
     // Keep this version at 1.5.11 for compatibility with Play 2.5; later versions depend on Play 2.6 already
     "com.beachape" %% "enumeratum-play-json" % "1.5.11"
   )
+
+  /**
+    * Types and DSL for URIs
+    */
+  val scalaUri: ModuleID = "io.lemonlabs" %% "scala-uri" % Versions.scalaUri
 
   /**
     * Property testing for Scala.

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -3,7 +3,10 @@
 # ~~~~
 
 # API routes
--> /api/v1  de.frosner.broccoli.ApiV1Router
+-> /api/v1  de.frosner.broccoli.routes.ApiV1Router
+
+# Downloads
+-> /downloads/ de.frosner.broccoli.routes.DownloadsRouter
 
 # Web-UI
 GET     /       @controllers.Assets.at(path="/public", file="index.html")

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -2,30 +2,8 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-# Templates
-GET     /api/v1/templates      @de.frosner.broccoli.controllers.TemplateController.list
-GET     /api/v1/templates/:id  @de.frosner.broccoli.controllers.TemplateController.show(id: String)
-
-# Instances
-GET     /api/v1/instances         @de.frosner.broccoli.controllers.InstanceController.list(templateId: Option[String])
-GET     /api/v1/instances/:id     @de.frosner.broccoli.controllers.InstanceController.show(id: String)
-POST    /api/v1/instances         @de.frosner.broccoli.controllers.InstanceController.create
-POST    /api/v1/instances/:id     @de.frosner.broccoli.controllers.InstanceController.update(id: String)
-DELETE  /api/v1/instances/:id     @de.frosner.broccoli.controllers.InstanceController.delete(id: String)
-GET  /api/v1/instances/:id/tasks  @de.frosner.broccoli.controllers.InstanceController.tasks(id: String)
-
-
-# About
-GET     /api/v1/about  @de.frosner.broccoli.controllers.AboutController.about
-
-# Status
-
-GET     /api/v1/status  @de.frosner.broccoli.controllers.StatusController.status
-
-# Authentication
-POST    /api/v1/auth/login   @de.frosner.broccoli.controllers.SecurityController.login()
-POST    /api/v1/auth/logout  @de.frosner.broccoli.controllers.SecurityController.logout()
-GET     /api/v1/auth/verify  @de.frosner.broccoli.controllers.SecurityController.verify()
+# API routes
+-> /api/v1  de.frosner.broccoli.ApiV1Router
 
 # Web-UI
 GET     /       @controllers.Assets.at(path="/public", file="index.html")

--- a/server/src/main/scala/de/frosner/broccoli/ApiRouter.scala
+++ b/server/src/main/scala/de/frosner/broccoli/ApiRouter.scala
@@ -1,3 +1,0 @@
-package de.frosner.broccoli
-
-class ApiRouter {}

--- a/server/src/main/scala/de/frosner/broccoli/ApiRouter.scala
+++ b/server/src/main/scala/de/frosner/broccoli/ApiRouter.scala
@@ -1,0 +1,3 @@
+package de.frosner.broccoli
+
+class ApiRouter {}

--- a/server/src/main/scala/de/frosner/broccoli/ApiV1Router.scala
+++ b/server/src/main/scala/de/frosner/broccoli/ApiV1Router.scala
@@ -1,0 +1,48 @@
+package de.frosner.broccoli
+
+import javax.inject.Inject
+
+import de.frosner.broccoli.controllers._
+import play.api.mvc.{Action, Results}
+import play.api.routing.Router.Routes
+import play.api.routing.sird._
+import play.api.routing.SimpleRouter
+
+/**
+  * Routes for Broccoli REST API.
+  *
+  * @param templates Controller for templates
+  * @param instances Controller for instances
+  * @param about Controller for application information
+  * @param status Controller for status application
+  * @param security Controller for authentication
+  */
+class ApiV1Router @Inject()(
+    templates: TemplateController,
+    instances: InstanceController,
+    about: AboutController,
+    status: StatusController,
+    security: SecurityController
+) extends SimpleRouter {
+  override def routes: Routes = {
+    // Templates
+    case GET(p"/templates")     => templates.list
+    case GET(p"/templates/$id") => templates.show(id)
+    // Instances
+    case GET(p"/instances" ? q_o"templateId=$id") => instances.list(id)
+    case GET(p"/instances/$id")                   => instances.show(id)
+    case POST(p"/instances")                      => instances.create
+    case POST(p"/instances/$id")                  => instances.update(id)
+    case DELETE(p"/instances/$id")                => instances.delete(id)
+    case GET(p"/instances/$id/tasks")             => instances.tasks(id)
+    // About & status
+    case GET(p"/about")  => about.about
+    case GET(p"/status") => status.status
+    // Authentication
+    case POST(p"/auth/login")  => security.login
+    case POST(p"/auth/logout") => security.logout
+    case GET(p"/auth/verify")  => security.verify
+    // Do not fall back to other routes for API requests, but return 404 directly
+    case _ => Action(Results.NotFound)
+  }
+}

--- a/server/src/main/scala/de/frosner/broccoli/controllers/InstanceController.scala
+++ b/server/src/main/scala/de/frosner/broccoli/controllers/InstanceController.scala
@@ -5,6 +5,7 @@ import javax.inject.Inject
 
 import cats.syntax.either._
 import de.frosner.broccoli.http.ToHTTPResult.ops._
+import de.frosner.broccoli.instances.NomadInstances
 import de.frosner.broccoli.models.InstanceCreation.instanceCreationReads
 import de.frosner.broccoli.models.InstanceUpdate.instanceUpdateReads
 import de.frosner.broccoli.models.Role.syntax._
@@ -18,6 +19,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller, Results}
 
 case class InstanceController @Inject()(
+    instances: NomadInstances,
     instanceService: InstanceService,
     override val securityService: SecurityService,
     override val cacheApi: CacheApi,
@@ -39,7 +41,7 @@ case class InstanceController @Inject()(
   }
 
   def tasks(id: String): Action[Unit] = AsyncStack(parse.empty) { implicit request =>
-    instanceService.getInstanceTasks(loggedIn)(id).value.map(_.toHTTPResult)
+    instances.getInstanceTasks(loggedIn)(id).value.map(_.toHTTPResult)
   }
 
   def create: Action[InstanceCreation] = StackAction(parse.json[InstanceCreation]) { implicit request =>

--- a/server/src/main/scala/de/frosner/broccoli/instances/NomadInstances.scala
+++ b/server/src/main/scala/de/frosner/broccoli/instances/NomadInstances.scala
@@ -1,0 +1,55 @@
+package de.frosner.broccoli.instances
+
+import javax.inject.Inject
+
+import cats.instances.future._
+import cats.data.EitherT
+import de.frosner.broccoli.models.{Account, InstanceError, InstanceTasks, Task}
+import de.frosner.broccoli.nomad.NomadClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Manage broccoli instances on top of Nomad
+  *
+  * @param nomadClient A client to access the Nomad API.
+  */
+class NomadInstances @Inject()(nomadClient: NomadClient)(implicit ec: ExecutionContext) {
+
+  /**
+    * Get all tasks of the given instance.
+    *
+    * In Nomad the hierarchy is normally "allocation -> tasks in that allocation".  However allocations have generic
+    * UUID whereas tasks have human-readable names, so we believe that tasks are easier as an "entry point" for the user
+    * in the UI.  Hence this method inverts the hierarchy of models returned by Nomad.
+    *
+    * @param user The user requesting tasks for the instance, for access control
+    * @param id The instance ID
+    * @return All tasks of the given instance with their allocations, or an empty list if the instance has no tasks or
+    *         didn't exist.  If the user may not access the instance return an InstanceError instead.
+    */
+  def getInstanceTasks(user: Account)(id: String): EitherT[Future, InstanceError, InstanceTasks] =
+    EitherT
+      .pure[Future, InstanceError](id)
+      .ensureOr(InstanceError.UserRegexDenied(_, user.instanceRegex))(_.matches(user.instanceRegex))
+      .semiflatMap(nomadClient.getAllocationsForJob)
+      .map { allocations =>
+        InstanceTasks(
+          id,
+          // Invert the order "allocation -> task" into "task -> allocation" (see doc comment)
+          allocations.payload
+            .flatMap(allocation => allocation.taskStates.mapValues(_ -> allocation))
+            .groupBy {
+              case (taskName, _) => taskName
+            }
+            .map {
+              case (taskId, items) =>
+                Task(taskId, items.map {
+                  case (_, (events, allocation)) =>
+                    Task.Allocation(allocation.id, allocation.clientStatus, events.state)
+                })
+            }
+            .toSeq
+        )
+      }
+}

--- a/server/src/main/scala/de/frosner/broccoli/instances/NomadInstances.scala
+++ b/server/src/main/scala/de/frosner/broccoli/instances/NomadInstances.scala
@@ -6,6 +6,8 @@ import cats.instances.future._
 import cats.data.EitherT
 import de.frosner.broccoli.models.{Account, InstanceError, InstanceTasks, Task}
 import de.frosner.broccoli.nomad.NomadClient
+import de.frosner.broccoli.nomad.models.Job
+import shapeless.tag
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -30,7 +32,7 @@ class NomadInstances @Inject()(nomadClient: NomadClient)(implicit ec: ExecutionC
     */
   def getInstanceTasks(user: Account)(id: String): EitherT[Future, InstanceError, InstanceTasks] =
     EitherT
-      .pure[Future, InstanceError](id)
+      .pure[Future, InstanceError](tag[Job.Id](id))
       .ensureOr(InstanceError.UserRegexDenied(_, user.instanceRegex))(_.matches(user.instanceRegex))
       .semiflatMap(nomadClient.getAllocationsForJob)
       .map { allocations =>

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
@@ -1,6 +1,8 @@
 package de.frosner.broccoli.nomad
 
-import de.frosner.broccoli.nomad.models.{Allocation, WithId}
+import cats.data.EitherT
+import de.frosner.broccoli.nomad.models._
+import shapeless.tag.@@
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -16,5 +18,27 @@ trait NomadClient {
     * @param jobId The ID of the job
     * @return The list of allocations for the job
     */
-  def getAllocationsForJob(jobId: String): Future[WithId[immutable.Seq[Allocation]]]
+  def getAllocationsForJob(jobId: String @@ Job.Id): Future[WithId[immutable.Seq[Allocation]]]
+
+  /**
+    * Get an allocation.
+    *
+    * @param id The alloction to query
+    * @return The allocation or an error
+    */
+  def getAllocation(id: @@[String, Allocation.Id]): EitherT[Future, NomadError, Allocation]
+
+  /**
+    * Get the log of a task on an allocation.
+    *
+    * @param allocationId The ID of the allocation
+    * @param taskName     The name of the task
+    * @param stream       The kind of log to fetch
+    * @return The task log
+    */
+  def getTaskLog(
+      allocationId: String @@ Allocation.Id,
+      taskName: String @@ Task.Name,
+      stream: LogStreamKind
+  ): EitherT[Future, NomadError, TaskLog]
 }

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
@@ -3,6 +3,8 @@ package de.frosner.broccoli.nomad
 import cats.data.EitherT
 import de.frosner.broccoli.nomad.models._
 import shapeless.tag.@@
+import squants.Quantity
+import squants.information.Information
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -34,11 +36,13 @@ trait NomadClient {
     * @param allocationId The ID of the allocation
     * @param taskName The name of the task
     * @param stream The kind of log to fetch
+    * @param offset The number of bytes to fetch from the end of the log.  If None fetch the entire log
     * @return The task log
     */
   def getTaskLog(
       allocationId: String @@ Allocation.Id,
       taskName: String @@ Task.Name,
-      stream: LogStreamKind
+      stream: LogStreamKind,
+      offset: Option[Quantity[Information] @@ TaskLog.Offset]
   ): EitherT[Future, NomadError, TaskLog]
 }

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadClient.scala
@@ -26,14 +26,14 @@ trait NomadClient {
     * @param id The alloction to query
     * @return The allocation or an error
     */
-  def getAllocation(id: @@[String, Allocation.Id]): EitherT[Future, NomadError, Allocation]
+  def getAllocation(id: String @@ Allocation.Id): EitherT[Future, NomadError, Allocation]
 
   /**
     * Get the log of a task on an allocation.
     *
     * @param allocationId The ID of the allocation
-    * @param taskName     The name of the task
-    * @param stream       The kind of log to fetch
+    * @param taskName The name of the task
+    * @param stream The kind of log to fetch
     * @return The task log
     */
   def getTaskLog(

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadHttpClient.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadHttpClient.scala
@@ -99,7 +99,9 @@ class NomadHttpClient(baseUri: Uri, client: WSClient)(implicit context: Executio
               "type" -> stream.entryName,
               // Request the plain text log without framing and do not follow the log
               "plain" -> "true",
-              "follow" -> "false"
+              "follow" -> "false",
+              "origin" -> "end",
+              "offset" -> "204800"
             )
             .withHeaders(ACCEPT -> TEXT)
             .get())

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadHttpClient.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadHttpClient.scala
@@ -1,7 +1,14 @@
 package de.frosner.broccoli.nomad
 
-import de.frosner.broccoli.nomad.models.{Allocation, WithId}
-import play.api.libs.ws.{WSClient, WSRequest}
+import cats.instances.future._
+import cats.data.EitherT
+import de.frosner.broccoli.nomad.models._
+import play.api.http.HeaderNames._
+import play.api.http.Status._
+import play.api.http.MimeTypes.{JSON, TEXT}
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
+import shapeless.tag
+import shapeless.tag.@@
 
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,12 +24,76 @@ class NomadHttpClient(baseUrl: String, client: WSClient)(implicit context: Execu
     * @param jobId The ID of the job
     * @return The list of allocations for the job
     */
-  override def getAllocationsForJob(jobId: String): Future[WithId[immutable.Seq[Allocation]]] =
+  override def getAllocationsForJob(jobId: String @@ Job.Id): Future[WithId[immutable.Seq[Allocation]]] =
     for {
       response <- url(s"job/$jobId/allocations")
-        .withHeaders("Accept" -> "application/json")
+        .withHeaders(ACCEPT -> JSON)
         .get()
     } yield WithId(jobId, response.json.as[immutable.Seq[Allocation]])
+
+  /**
+    * Get an allocation.
+    *
+    * @param id The alloction to query
+    * @return The allocation or an error
+    */
+  override def getAllocation(id: String @@ Allocation.Id): EitherT[Future, NomadError, Allocation] =
+    EitherT
+      .right(
+        url(s"allocation/$id")
+          .withHeaders(ACCEPT -> JSON)
+          .get())
+      .ensureOr(toError)(_.status == OK)
+      .map(_.json.as[Allocation])
+
+  /**
+    * Get the log of a task on an allocation.
+    *
+    * Nomad provides logs of tasks, but getting hold of these involves a few requests as Nomad only exposes logs as part
+    * of the client API.  This API has an important restriction: We must request those endpoints from the node that runs
+    * the allocation of interest.  We cannot simply ask any other Nomad server, ie, the one Broccoli uses for everything
+    * else.
+    *
+    * So we
+    *
+    * - request the allocation to find out the ID of the node it runs on,
+    * - request information about the node with that ID to get the HTTP API address of the node,
+    * - and finally ask that address for the logs.
+    *
+    * @param allocationId The ID of the allocation
+    * @param taskName     The name of the task
+    * @param stream       The kind of log to fetch
+    * @return The task log
+    */
+  override def getTaskLog(
+      allocationId: String @@ Allocation.Id,
+      taskName: String @@ Task.Name,
+      stream: LogStreamKind
+  ): EitherT[Future, NomadError, TaskLog] =
+    for {
+      allocation <- getAllocation(allocationId)
+      allocationNode <- EitherT
+        .right(
+          url(s"node/${allocation.nodeId}")
+            .withHeaders(ACCEPT -> JSON)
+            .get())
+        .ensureOr(toError)(_.status == OK)
+        .map(_.json.as[Node])
+      log <- EitherT
+        .right(
+          client
+            .url(s"${allocationNode.httpAddress}/v1/client/fs/logs/$allocationId")
+            .withQueryString(
+              "task" -> taskName,
+              "type" -> stream.entryName,
+              // Request the plain text log without frameing and do not follow the log
+              "plain" -> "true",
+              "follow" -> "false"
+            )
+            .withHeaders(ACCEPT -> TEXT)
+            .get())
+        .ensureOr(toError)(_.status == OK)
+    } yield TaskLog(stream, tag[TaskLog.Contents](log.body))
 
   /**
     * Build a web request with the given API path (without /v1/ prefix).
@@ -31,4 +102,10 @@ class NomadHttpClient(baseUrl: String, client: WSClient)(implicit context: Execu
     * @return The corresponding web request.
     */
   private def url(apiPath: String): WSRequest = client.url(s"$baseUrl/v1/$apiPath")
+
+  private def toError(response: WSResponse): NomadError = response.status match {
+    case NOT_FOUND => NomadError.NotFound
+    // For unexpected errors throw an exception instead to trigger logging
+    case _ => throw new UnexpectedNomadHttpApiError(response)
+  }
 }

--- a/server/src/main/scala/de/frosner/broccoli/nomad/NomadModule.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/NomadModule.scala
@@ -3,6 +3,7 @@ package de.frosner.broccoli.nomad
 import javax.inject.Singleton
 
 import com.google.inject.{AbstractModule, Provides}
+import com.netaporter.uri.Uri
 import net.codingwell.scalaguice.ScalaModule
 import play.api.Configuration
 import play.api.libs.ws.WSClient
@@ -37,5 +38,5 @@ class NomadModule extends AbstractModule with ScalaModule {
   @Provides
   @Singleton
   def provideNomadClient(config: NomadConfiguration, wsClient: WSClient): NomadClient =
-    new NomadHttpClient(config.url, wsClient)(play.api.libs.concurrent.Execution.defaultContext)
+    new NomadHttpClient(Uri.parse(config.url), wsClient)(play.api.libs.concurrent.Execution.defaultContext)
 }

--- a/server/src/main/scala/de/frosner/broccoli/nomad/UnexpectedNomadHttpApiError.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/UnexpectedNomadHttpApiError.scala
@@ -1,0 +1,11 @@
+package de.frosner.broccoli.nomad
+
+import play.api.libs.ws.WSResponse
+
+/**
+  * An unexpected and unhandled response from the Nomad API.
+  *
+  * @param response The original response
+  */
+class UnexpectedNomadHttpApiError(val response: WSResponse)
+    extends Exception(s"Unexpected Nomad response: ${response.status} ${response.statusText}") {}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/Allocation.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/Allocation.scala
@@ -2,20 +2,31 @@ package de.frosner.broccoli.nomad.models
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Reads}
+import shapeless.tag
+import shapeless.tag.@@
 
 /**
   * A partial model for a single allocations.
   */
-final case class Allocation(id: String,
-                            nodeId: String,
-                            clientStatus: ClientStatus,
-                            taskStates: Map[String, TaskStateEvents])
+final case class Allocation(
+    id: String @@ Allocation.Id,
+    jobId: String @@ Job.Id,
+    nodeId: String @@ Node.Id,
+    clientStatus: ClientStatus,
+    taskStates: Map[String @@ Task.Name, TaskStateEvents]
+)
 
 object Allocation {
+  trait Id
+
   implicit val allocationReads: Reads[Allocation] =
-    ((JsPath \ "ID").read[String] and
-      (JsPath \ "NodeID").read[String] and
+    ((JsPath \ "ID").read[String].map(tag[Allocation.Id](_)) and
+      (JsPath \ "JobID").read[String].map(tag[Job.Id](_)) and
+      (JsPath \ "NodeID").read[String].map(tag[Node.Id](_)) and
       (JsPath \ "ClientStatus").read[ClientStatus] and
-      (JsPath \ "TaskStates").readNullable[Map[String, TaskStateEvents]].map(_.getOrElse(Map.empty)))(
-      Allocation.apply _)
+      (JsPath \ "TaskStates")
+        .readNullable[Map[String, TaskStateEvents]]
+        // Tag all values as task name. Since Task.Name is a phantom type this is a safe thing to do, albeit it doesn't
+        // look like so
+        .map(_.getOrElse(Map.empty).asInstanceOf[Map[String @@ Task.Name, TaskStateEvents]]))(Allocation.apply _)
 }

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/Job.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/Job.scala
@@ -6,6 +6,7 @@ import play.api.libs.functional.syntax._
 final case class Job(taskGroups: Option[Seq[TaskGroup]])
 
 object Job {
+  sealed trait Id
 
   implicit val jobFormat: Format[Job] =
     (__ \ "TaskGroups")

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/LogStreamKind.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/LogStreamKind.scala
@@ -24,15 +24,4 @@ object LogStreamKind extends Enum[LogStreamKind] {
     * The standard error stream of a task.
     */
   case object StdErr extends LogStreamKind
-
-  /**
-    * Use log stream kinds in Play route paths.
-    */
-  implicit def logStreamKindPathBindable(implicit stringBinder: PathBindable[String]): PathBindable[LogStreamKind] =
-    new PathBindable[LogStreamKind] {
-      override def bind(key: String, value: String): Either[String, LogStreamKind] =
-        stringBinder.bind(key, value).flatMap(LogStreamKind.withNameOption(_).toRight("Invalid log kind"))
-
-      override def unbind(_key: String, value: LogStreamKind): String = value.entryName
-    }
 }

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/LogStreamKind.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/LogStreamKind.scala
@@ -1,0 +1,38 @@
+package de.frosner.broccoli.nomad.models
+
+import enumeratum._
+import cats.syntax.either._
+import play.api.mvc.PathBindable
+
+import scala.collection.immutable
+
+/**
+  * The kind of log stream of a client.
+  */
+sealed trait LogStreamKind extends EnumEntry with EnumEntry.Lowercase
+
+object LogStreamKind extends Enum[LogStreamKind] {
+
+  override def values: immutable.IndexedSeq[LogStreamKind] = findValues
+
+  /**
+    * The standard output stream of a task.
+    */
+  case object StdOut extends LogStreamKind
+
+  /**
+    * The standard error stream of a task.
+    */
+  case object StdErr extends LogStreamKind
+
+  /**
+    * Use log stream kinds in Play route paths.
+    */
+  implicit def logStreamKindPathBindable(implicit stringBinder: PathBindable[String]): PathBindable[LogStreamKind] =
+    new PathBindable[LogStreamKind] {
+      override def bind(key: String, value: String): Either[String, LogStreamKind] =
+        stringBinder.bind(key, value).flatMap(LogStreamKind.withNameOption(_).toRight("Invalid log kind"))
+
+      override def unbind(_key: String, value: LogStreamKind): String = value.entryName
+    }
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/Node.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/Node.scala
@@ -1,0 +1,31 @@
+package de.frosner.broccoli.nomad.models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+import shapeless.tag
+import shapeless.tag.@@
+
+/**
+  * A partial model of a Nomad node.
+  *
+  * @param id The Nomad ID (as UUID)
+  * @param name The name of the node
+  * @param httpAddress The HTTP address of the node, for client API requests
+  */
+final case class Node(
+    id: String @@ Node.Id,
+    name: String @@ Node.Name,
+    httpAddress: String @@ Node.HttpAddress
+)
+
+object Node {
+  sealed trait Id
+  sealed trait Name
+  sealed trait HttpAddress
+
+  implicit val nodeReads: Reads[Node] = (
+    (JsPath \ "ID").read[String].map(tag[Id](_)) and
+      (JsPath \ "Name").read[String].map(tag[Name](_)) and
+      (JsPath \ "HTTPAddr").read[String].map(tag[HttpAddress](_))
+  )(Node.apply _)
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/NomadError.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/NomadError.scala
@@ -1,0 +1,15 @@
+package de.frosner.broccoli.nomad.models
+
+/**
+  * Errors from the Nomad API.
+  */
+sealed trait NomadError
+
+object NomadError {
+
+  /**
+    * A Nomad object (job, allocation, etc.) was not found
+    */
+  final case object NotFound extends NomadError
+
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/Task.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/Task.scala
@@ -6,6 +6,7 @@ import play.api.libs.functional.syntax._
 final case class Task(services: Option[Seq[Service]])
 
 object Task {
+  sealed trait Name
 
   implicit val taskFormat: Format[Task] =
     (__ \ "Services")

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskLog.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskLog.scala
@@ -1,0 +1,15 @@
+package de.frosner.broccoli.nomad.models
+
+import shapeless.tag.@@
+
+/**
+  * The log of a task.
+  *
+  * @param kind The kind of log
+  * @param contents The log
+  */
+final case class TaskLog(kind: LogStreamKind, contents: String @@ TaskLog.Contents)
+
+object TaskLog {
+  sealed trait Contents
+}

--- a/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskLog.scala
+++ b/server/src/main/scala/de/frosner/broccoli/nomad/models/TaskLog.scala
@@ -11,5 +11,6 @@ import shapeless.tag.@@
 final case class TaskLog(kind: LogStreamKind, contents: String @@ TaskLog.Contents)
 
 object TaskLog {
+  sealed trait Offset
   sealed trait Contents
 }

--- a/server/src/main/scala/de/frosner/broccoli/routes/ApiV1Router.scala
+++ b/server/src/main/scala/de/frosner/broccoli/routes/ApiV1Router.scala
@@ -2,6 +2,7 @@ package de.frosner.broccoli.routes
 
 import javax.inject.Inject
 
+import com.google.inject.Provider
 import de.frosner.broccoli.controllers._
 import play.api.mvc.{Action, Results}
 import play.api.routing.Router.Routes
@@ -18,30 +19,30 @@ import play.api.routing.sird._
   * @param security Controller for authentication
   */
 class ApiV1Router @Inject()(
-    templates: TemplateController,
-    instances: InstanceController,
-    about: AboutController,
-    status: StatusController,
-    security: SecurityController
+    templates: Provider[TemplateController],
+    instances: Provider[InstanceController],
+    about: Provider[AboutController],
+    status: Provider[StatusController],
+    security: Provider[SecurityController]
 ) extends SimpleRouter {
   override def routes: Routes = {
     // Templates
-    case GET(p"/templates")     => templates.list
-    case GET(p"/templates/$id") => templates.show(id)
+    case GET(p"/templates")     => templates.get.list
+    case GET(p"/templates/$id") => templates.get.show(id)
     // Instances
-    case GET(p"/instances" ? q_o"templateId=$id") => instances.list(id)
-    case GET(p"/instances/$id")                   => instances.show(id)
-    case POST(p"/instances")                      => instances.create
-    case POST(p"/instances/$id")                  => instances.update(id)
-    case DELETE(p"/instances/$id")                => instances.delete(id)
-    case GET(p"/instances/$id/tasks")             => instances.tasks(id)
+    case GET(p"/instances" ? q_o"templateId=$id") => instances.get.list(id)
+    case GET(p"/instances/$id")                   => instances.get.show(id)
+    case POST(p"/instances")                      => instances.get.create
+    case POST(p"/instances/$id")                  => instances.get.update(id)
+    case DELETE(p"/instances/$id")                => instances.get.delete(id)
+    case GET(p"/instances/$id/tasks")             => instances.get.tasks(id)
     // About & status
-    case GET(p"/about")  => about.about
-    case GET(p"/status") => status.status
+    case GET(p"/about")  => about.get.about
+    case GET(p"/status") => status.get.status
     // Authentication
-    case POST(p"/auth/login")  => security.login
-    case POST(p"/auth/logout") => security.logout
-    case GET(p"/auth/verify")  => security.verify
+    case POST(p"/auth/login")  => security.get.login
+    case POST(p"/auth/logout") => security.get.logout
+    case GET(p"/auth/verify")  => security.get.verify
     // Do not fall back to other routes for API requests, but return 404 directly
     case _ => Action(Results.NotFound)
   }

--- a/server/src/main/scala/de/frosner/broccoli/routes/ApiV1Router.scala
+++ b/server/src/main/scala/de/frosner/broccoli/routes/ApiV1Router.scala
@@ -1,12 +1,12 @@
-package de.frosner.broccoli
+package de.frosner.broccoli.routes
 
 import javax.inject.Inject
 
 import de.frosner.broccoli.controllers._
 import play.api.mvc.{Action, Results}
 import play.api.routing.Router.Routes
-import play.api.routing.sird._
 import play.api.routing.SimpleRouter
+import play.api.routing.sird._
 
 /**
   * Routes for Broccoli REST API.

--- a/server/src/main/scala/de/frosner/broccoli/routes/DownloadsRouter.scala
+++ b/server/src/main/scala/de/frosner/broccoli/routes/DownloadsRouter.scala
@@ -1,0 +1,21 @@
+package de.frosner.broccoli.routes
+
+import javax.inject.Inject
+
+import de.frosner.broccoli.controllers.InstanceController
+import de.frosner.broccoli.nomad.models.LogStreamKind
+import play.api.mvc.{Action, Results}
+import play.api.routing.Router.Routes
+import play.api.routing.SimpleRouter
+import play.api.routing.sird._
+import play.api.http.ContentTypes._
+
+class DownloadsRouter @Inject()(instances: InstanceController) extends SimpleRouter {
+  private val logKind: PathBindableExtractor[LogStreamKind] = new PathBindableExtractor[LogStreamKind]
+
+  override def routes: Routes = {
+    case GET(p"/instances/$instanceId/allocations/$allocationId/tasks/$taskName/logs/${logKind(kind)}") =>
+      instances.logFile(instanceId, allocationId, taskName, kind)
+    case _ => Action(Results.NotFound(<h1>Download not found</h1>).as(HTML))
+  }
+}

--- a/server/src/main/scala/de/frosner/broccoli/routes/DownloadsRouter.scala
+++ b/server/src/main/scala/de/frosner/broccoli/routes/DownloadsRouter.scala
@@ -3,7 +3,7 @@ package de.frosner.broccoli.routes
 import javax.inject.Inject
 
 import de.frosner.broccoli.controllers.InstanceController
-import de.frosner.broccoli.nomad.models.LogStreamKind
+import de.frosner.broccoli.routes.Extractors._
 import play.api.mvc.{Action, Results}
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
@@ -11,11 +11,11 @@ import play.api.routing.sird._
 import play.api.http.ContentTypes._
 
 class DownloadsRouter @Inject()(instances: InstanceController) extends SimpleRouter {
-  private val logKind: PathBindableExtractor[LogStreamKind] = new PathBindableExtractor[LogStreamKind]
 
   override def routes: Routes = {
-    case GET(p"/instances/$instanceId/allocations/$allocationId/tasks/$taskName/logs/${logKind(kind)}") =>
-      instances.logFile(instanceId, allocationId, taskName, kind)
+    case GET(
+        p"/instances/$instanceId/allocations/$allocationId/tasks/$taskName/logs/${logKind(kind)}" ? q_o"offset=${information(offset)}") =>
+      instances.logFile(instanceId, allocationId, taskName, kind, offset)
     case _ => Action(Results.NotFound(<h1>Download not found</h1>).as(HTML))
   }
 }

--- a/server/src/main/scala/de/frosner/broccoli/routes/DownloadsRouter.scala
+++ b/server/src/main/scala/de/frosner/broccoli/routes/DownloadsRouter.scala
@@ -1,6 +1,6 @@
 package de.frosner.broccoli.routes
 
-import javax.inject.Inject
+import javax.inject.{Inject, Provider}
 
 import de.frosner.broccoli.controllers.InstanceController
 import de.frosner.broccoli.routes.Extractors._
@@ -10,12 +10,12 @@ import play.api.routing.SimpleRouter
 import play.api.routing.sird._
 import play.api.http.ContentTypes._
 
-class DownloadsRouter @Inject()(instances: InstanceController) extends SimpleRouter {
+class DownloadsRouter @Inject()(instances: Provider[InstanceController]) extends SimpleRouter {
 
   override def routes: Routes = {
     case GET(
         p"/instances/$instanceId/allocations/$allocationId/tasks/$taskName/logs/${logKind(kind)}" ? q_o"offset=${information(offset)}") =>
-      instances.logFile(instanceId, allocationId, taskName, kind, offset)
+      instances.get.logFile(instanceId, allocationId, taskName, kind, offset)
     case _ => Action(Results.NotFound(<h1>Download not found</h1>).as(HTML))
   }
 }

--- a/server/src/main/scala/de/frosner/broccoli/routes/Extractors.scala
+++ b/server/src/main/scala/de/frosner/broccoli/routes/Extractors.scala
@@ -1,0 +1,24 @@
+package de.frosner.broccoli.routes
+
+import de.frosner.broccoli.nomad.models.LogStreamKind
+import play.api.routing.sird.PathBindableExtractor
+import squants.information.Information
+
+/**
+  * Additional extractors for string DSL routes.
+  */
+trait Extractors {
+  import PathBinders._
+
+  /**
+    * The kind of a log.
+    */
+  val logKind: PathBindableExtractor[LogStreamKind] = new PathBindableExtractor[LogStreamKind]
+
+  /**
+    * Extract units of information from paths.
+    */
+  val information: PathBindableExtractor[Information] = new PathBindableExtractor[Information]
+}
+
+object Extractors extends Extractors

--- a/server/src/main/scala/de/frosner/broccoli/routes/PathBinders.scala
+++ b/server/src/main/scala/de/frosner/broccoli/routes/PathBinders.scala
@@ -1,0 +1,44 @@
+package de.frosner.broccoli.routes
+
+import cats.syntax.either._
+import de.frosner.broccoli.nomad.models.LogStreamKind
+import play.api.mvc.PathBindable
+import squants.information.Information
+
+/**
+  * Bind values to route paths.
+  */
+trait PathBinders {
+
+  /**
+    * Use log stream kinds in Play route paths.
+    */
+  implicit def logStreamKindPathBindable(implicit stringBinder: PathBindable[String]): PathBindable[LogStreamKind] =
+    new PathBindable[LogStreamKind] {
+      override def bind(key: String, value: String): Either[String, LogStreamKind] =
+        for {
+          boundValue <- stringBinder.bind(key, value)
+          kind <- LogStreamKind.withNameOption(boundValue).toRight("Invalid log kind")
+        } yield kind
+
+      override def unbind(key: String, value: LogStreamKind): String = stringBinder.unbind(key, value.entryName)
+    }
+
+  /**
+    * Bind information units to route paths.
+    */
+  implicit def informationPathBindable(implicit stringBinder: PathBindable[String]): PathBindable[Information] =
+    new PathBindable[Information] {
+      override def bind(key: String, value: String): Either[String, Information] =
+        for {
+          boundValue <- stringBinder.bind(key, value)
+          information <- Either
+            .fromTry(Information(boundValue))
+            .leftMap(_.getMessage)
+        } yield information
+
+      override def unbind(key: String, value: Information): String = stringBinder.unbind(key, value.toString)
+    }
+}
+
+object PathBinders extends PathBinders

--- a/server/src/main/scala/de/frosner/broccoli/services/InstanceService.scala
+++ b/server/src/main/scala/de/frosner/broccoli/services/InstanceService.scala
@@ -20,6 +20,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 @Singleton
+@deprecated(message = "Tear apart and move functionality to the \"instances\" package", since = "2017-08-16")
 class InstanceService @Inject()(nomadClient: NomadClient,
                                 templateService: TemplateService,
                                 nomadService: NomadService,
@@ -306,40 +307,4 @@ class InstanceService @Inject()(nomadClient: NomadClient,
     tryDelete.map(addStatuses)
   }
 
-  /**
-    * Get all tasks of the given instance.
-    *
-    * In Nomad the hierarchy is normally "allocation -> tasks in that allocation".  However allocations have generic
-    * UUID whereas tasks have human-readable names, so we believe that tasks are easier as an "entry point" for the user
-    * in the UI.  Hence this method inverts the hierarchy of models returned by Nomad.
-    *
-    * @param user The user requesting tasks for the instance, for access control
-    * @param id The instance ID
-    * @return All tasks of the given instance with their allocations, or an empty list if the instance has no tasks or
-    *         didn't exist.  If the user may not access the instance return an InstanceError instead.
-    */
-  def getInstanceTasks(user: Account)(id: String): EitherT[Future, InstanceError, InstanceTasks] =
-    EitherT
-      .pure[Future, InstanceError](id)
-      .ensureOr(InstanceError.UserRegexDenied(_, user.instanceRegex))(_.matches(user.instanceRegex))
-      .semiflatMap(nomadClient.getAllocationsForJob)
-      .map { allocations =>
-        InstanceTasks(
-          id,
-          // Invert the order "allocation -> task" into "task -> allocation" (see doc comment)
-          allocations.payload
-            .flatMap(allocation => allocation.taskStates.mapValues(_ -> allocation))
-            .groupBy {
-              case (taskName, _) => taskName
-            }
-            .map {
-              case (taskId, items) =>
-                Task(taskId, items.map {
-                  case (_, (events, allocation)) =>
-                    Task.Allocation(allocation.id, allocation.clientStatus, events.state)
-                })
-            }
-            .toSeq
-        )
-      }
 }

--- a/server/src/main/scala/de/frosner/broccoli/websocket/WebSocketMessageHandler.scala
+++ b/server/src/main/scala/de/frosner/broccoli/websocket/WebSocketMessageHandler.scala
@@ -5,6 +5,7 @@ import javax.inject.Inject
 import cats.syntax.either._
 import cats.instances.future._
 import de.frosner.broccoli.controllers.InstanceController
+import de.frosner.broccoli.instances.NomadInstances
 import de.frosner.broccoli.models.Account
 import de.frosner.broccoli.services.InstanceService
 import de.frosner.broccoli.websocket.OutgoingMessage._
@@ -30,7 +31,8 @@ trait WebSocketMessageHandler {
 /**
   * Process broccoli's websocket messages.
   */
-class BroccoliMessageHandler @Inject()(instanceService: InstanceService)(implicit ec: ExecutionContext)
+class BroccoliMessageHandler @Inject()(instances: NomadInstances, instanceService: InstanceService)(
+    implicit ec: ExecutionContext)
     extends WebSocketMessageHandler {
 
   override def processMessage(user: Account)(incomingMessage: IncomingMessage): Future[OutgoingMessage] =
@@ -51,7 +53,7 @@ class BroccoliMessageHandler @Inject()(instanceService: InstanceService)(implici
           .toEitherT
           .fold(UpdateInstanceError, UpdateInstanceSuccess)
       case GetInstanceTasks(instanceId) =>
-        instanceService
+        instances
           .getInstanceTasks(user)(instanceId)
           .fold(GetInstanceTasksError, GetInstanceTasksSuccess)
     }

--- a/server/src/test/resources/de/frosner/broccoli/services/nomad/node.json
+++ b/server/src/test/resources/de/frosner/broccoli/services/nomad/node.json
@@ -1,0 +1,78 @@
+{
+  "Attributes": {
+    "consul.datacenter": "dc1",
+    "consul.revision": "2c77151",
+    "consul.server": "true",
+    "consul.version": "0.8.5",
+    "cpu.arch": "amd64",
+    "cpu.frequency": "2397",
+    "cpu.modelname": "Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz",
+    "cpu.numcores": "8",
+    "cpu.totalcompute": "19176",
+    "driver.docker": "1",
+    "driver.docker.version": "17.06.0-ce",
+    "driver.docker.volumes.enabled": "1",
+    "driver.exec": "1",
+    "driver.java": "1",
+    "driver.java.runtime": "Java(TM) SE Runtime Environment (build 1.8.0_74-b02)",
+    "driver.java.version": "1.8.0_74",
+    "driver.java.vm": "Java HotSpot(TM) 64-Bit Server VM (build 25.74-b02, mixed mode)",
+    "driver.raw_exec": "1",
+    "kernel.name": "linux",
+    "kernel.version": "4.2.0-42-generic",
+    "memory.totalbytes": "21045665792",
+    "nomad.revision": "4cd2cf1c3c9ed6dbd0b8261f9bad0e375c182d7f+CHANGES",
+    "nomad.version": "0.5.6",
+    "os.name": "ubuntu",
+    "os.signals": "SIGABRT,SIGSEGV,SIGUSR1,SIGXCPU,SIGSTOP,SIGTTOU,SIGUSR2,SIGILL,SIGTERM,SIGXFSZ,SIGHUP,SIGIOT,SIGKILL,SIGQUIT,SIGINT,SIGPROF,SIGTTIN,SIGURG,SIGCHLD,SIGIO,SIGPIPE,SIGTSTP,SIGALRM,SIGTRAP,SIGBUS,SIGCONT,SIGFPE,SIGSYS",
+    "os.version": "14.04",
+    "unique.cgroup.mountpoint": "/sys/fs/cgroup",
+    "unique.consul.name": "vc31",
+    "unique.hostname": "vc31",
+    "unique.network.ip-address": "127.0.0.1",
+    "unique.storage.bytesfree": "155372511232",
+    "unique.storage.bytestotal": "184696553472",
+    "unique.storage.volume": "/dev/xvda1"
+  },
+  "ComputedClass": "v1:5736492678711156523",
+  "CreateIndex": 5,
+  "Datacenter": "dc1",
+  "Drain": false,
+  "HTTPAddr": "127.0.0.1:4646",
+  "ID": "4beac5b7-3974-3ddf-b572-9db5906fb891",
+  "Links": {
+    "consul": "dc1.vc31"
+  },
+  "Meta": null,
+  "ModifyIndex": 6,
+  "Name": "vc31",
+  "NodeClass": "",
+  "Reserved": {
+    "CPU": 0,
+    "DiskMB": 0,
+    "IOPS": 0,
+    "MemoryMB": 0,
+    "Networks": null
+  },
+  "Resources": {
+    "CPU": 19176,
+    "DiskMB": 148174,
+    "IOPS": 0,
+    "MemoryMB": 20070,
+    "Networks": [
+      {
+        "CIDR": "127.0.0.1/32",
+        "Device": "lo",
+        "DynamicPorts": null,
+        "IP": "127.0.0.1",
+        "MBits": 1000,
+        "ReservedPorts": null
+      }
+    ]
+  },
+  "SecretID": "",
+  "Status": "ready",
+  "StatusDescription": "",
+  "StatusUpdatedAt": 1502884373,
+  "TLSEnabled": false
+}

--- a/server/src/test/scala/de/frosner/broccoli/nomad/models/AllocationSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/nomad/models/AllocationSpec.scala
@@ -14,13 +14,14 @@ class AllocationSpec extends Specification {
         .validate[List[Allocation]]
         .asEither
 
-      val allocation = Allocation(
-        id = "520bc6c3-53c9-fd2e-5bea-7d0b9dbef254",
-        nodeId = "cf3338e9-5ed0-88ef-df7b-9dd9708130c8",
-        clientStatus = ClientStatus.Running,
-        taskStates = Map("http-task" -> TaskStateEvents(TaskState.Running))
-      )
-      allocations should beRight(List(allocation))
+      allocations should beRight(
+        List(Allocation(
+          id = shapeless.tag[Allocation.Id]("520bc6c3-53c9-fd2e-5bea-7d0b9dbef254"),
+          jobId = shapeless.tag[Job.Id]("tvftarcxrPoy9wNhghqQogihjha"),
+          nodeId = shapeless.tag[Node.Id]("cf3338e9-5ed0-88ef-df7b-9dd9708130c8"),
+          clientStatus = ClientStatus.Running,
+          taskStates = Map(shapeless.tag[Task.Name]("http-task") -> TaskStateEvents(TaskState.Running))
+        )))
     }
   }
 }

--- a/server/src/test/scala/de/frosner/broccoli/nomad/models/NodeSpec.scala
+++ b/server/src/test/scala/de/frosner/broccoli/nomad/models/NodeSpec.scala
@@ -1,0 +1,23 @@
+package de.frosner.broccoli.nomad.models
+
+import de.frosner.broccoli.util.Resources
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+class NodeSpec extends Specification {
+  "Node" should {
+    "decode from JSON" in {
+      val node = Json
+        .parse(Resources.readAsString("/de/frosner/broccoli/services/nomad/node.json"))
+        .validate[Node]
+        .asEither
+
+      node should beRight(
+        Node(
+          id = shapeless.tag[Node.Id]("4beac5b7-3974-3ddf-b572-9db5906fb891"),
+          name = shapeless.tag[Node.Name]("vc31"),
+          httpAddress = shapeless.tag[Node.HttpAddress]("127.0.0.1:4646")
+        ))
+    }
+  }
+}

--- a/webui/src/Models/Resources/LogKind.elm
+++ b/webui/src/Models/Resources/LogKind.elm
@@ -1,0 +1,21 @@
+module Models.Resources.LogKind exposing (..)
+
+{-| Provides log kind
+-}
+
+
+{-| The kind of log to view
+-}
+type LogKind
+    = StdOut
+    | StdErr
+
+
+toParameter : LogKind -> String
+toParameter kind =
+    case kind of
+        StdOut ->
+            "stdout"
+
+        StdErr ->
+            "stderr"

--- a/webui/src/Views/InstanceView.elm
+++ b/webui/src/Views/InstanceView.elm
@@ -376,7 +376,10 @@ instanceTasksView instance instanceTasks =
                     [ text "No tasks have been allocated, yet." ]
 
                 Just allocations ->
-                    [ table [ class "table table-condensed table-hover" ]
+                    [ table
+                        [ class "table table-condensed table-hover"
+                        , style [ ( "table-layout", "fixed" ) ]
+                        ]
                         [ thead []
                             [ tr []
                                 [ th [] [ text "Task" ]

--- a/webui/src/Views/InstanceView.elm
+++ b/webui/src/Views/InstanceView.elm
@@ -378,14 +378,15 @@ instanceTasksView instance instanceTasks =
                 Just allocations ->
                     [ table
                         [ class "table table-condensed table-hover"
-                        , style [ ( "table-layout", "fixed" ) ]
                         ]
-                        [ thead []
+                        [ thead
+                            -- Do not wrap table headers
+                            [ style [ ( "white-space", "nowrap" ) ] ]
                             [ tr []
-                                [ th [] [ text "Task" ]
-                                , th [] [ text "Allocation ID" ]
-                                , th [ class "text-center" ] [ text "State" ]
-                                , th [ class "text-center" ] [ text "Log files" ]
+                                [ th [] [ text "Allocation ID" ]
+                                , th [] [ text "State" ]
+                                , th [ style [ ( "width", "100%" ) ] ] [ text "Task" ]
+                                , th [] [ text "Log files" ]
                                 ]
                             ]
                         , tbody [] <| List.indexedMap (instanceAllocationRow instance) allocations
@@ -440,12 +441,14 @@ instanceAllocationRow instance index ( taskName, allocation ) =
                     ( "running", "label-success" )
     in
         tr []
-            [ th [ scope <| toString (index + 1) ] [ text taskName ]
-            , td [] [ code [] [ text (shortAllocationId allocation.id) ] ]
-            , td [ class "text-center" ]
+            [ td [] [ code [] [ text (shortAllocationId allocation.id) ] ]
+            , td []
                 [ span [ class ("label " ++ labelKind) ] [ text description ]
                 ]
-            , td [ class "text-center" ]
+            , td [] [ text taskName ]
+            , td
+                -- Do not wrap buttons in this cell
+                [ style [ ( "white-space", "nowrap" ) ] ]
                 [ a
                     [ href (logUrl instance taskName allocation StdOut)
                     , target "_blank"

--- a/webui/src/Views/InstanceView.elm
+++ b/webui/src/Views/InstanceView.elm
@@ -444,14 +444,14 @@ instanceAllocationRow instance index ( taskName, allocation ) =
                 [ a
                     [ href (logUrl instance taskName allocation StdOut)
                     , target "_blank"
-                    , class "btn btn-primary btn-xs"
+                    , class "btn btn-info btn-xs"
                     ]
                     [ text "stdout" ]
                 , text " "
                 , a
                     [ href (logUrl instance taskName allocation StdErr)
                     , target "_blank"
-                    , class "btn btn-primary btn-xs"
+                    , class "btn btn-info btn-xs"
                     ]
                     [ text "stderr" ]
                 ]

--- a/webui/src/Views/InstanceView.elm
+++ b/webui/src/Views/InstanceView.elm
@@ -416,6 +416,9 @@ logUrl instance taskName allocation kind =
 
             StdErr ->
                 "stderr"
+
+        -- Only fetch the last 500 KiB of the log, to avoid large requests and download times
+        , "?offset=500KiB"
         ]
 
 

--- a/webui/src/Views/InstanceView.elm
+++ b/webui/src/Views/InstanceView.elm
@@ -381,8 +381,8 @@ instanceTasksView instance instanceTasks =
                             [ tr []
                                 [ th [] [ text "Task" ]
                                 , th [] [ text "Allocation ID" ]
-                                , th [] [ text "State" ]
-                                , th [] [ text "Download log files" ]
+                                , th [ class "text-center" ] [ text "State" ]
+                                , th [ class "text-center" ] [ text "Log files" ]
                                 ]
                             ]
                         , tbody [] <| List.indexedMap (instanceAllocationRow instance) allocations
@@ -439,8 +439,10 @@ instanceAllocationRow instance index ( taskName, allocation ) =
         tr []
             [ th [ scope <| toString (index + 1) ] [ text taskName ]
             , td [] [ code [] [ text (shortAllocationId allocation.id) ] ]
-            , td [] [ span [ class ("label " ++ labelKind) ] [ text description ] ]
-            , td []
+            , td [ class "text-center" ]
+                [ span [ class ("label " ++ labelKind) ] [ text description ]
+                ]
+            , td [ class "text-center" ]
                 [ a
                     [ href (logUrl instance taskName allocation StdOut)
                     , target "_blank"

--- a/webui/src/Views/InstanceView.elm
+++ b/webui/src/Views/InstanceView.elm
@@ -384,9 +384,9 @@ instanceTasksView instance instanceTasks =
                             [ style [ ( "white-space", "nowrap" ) ] ]
                             [ tr []
                                 [ th [] [ text "Allocation ID" ]
-                                , th [] [ text "State" ]
+                                , th [ class "text-center" ] [ text "State" ]
                                 , th [ style [ ( "width", "100%" ) ] ] [ text "Task" ]
-                                , th [] [ text "Log files" ]
+                                , th [ class "text-center" ] [ text "Task logs" ]
                                 ]
                             ]
                         , tbody [] <| List.indexedMap (instanceAllocationRow instance) allocations
@@ -442,13 +442,13 @@ instanceAllocationRow instance index ( taskName, allocation ) =
     in
         tr []
             [ td [] [ code [] [ text (shortAllocationId allocation.id) ] ]
-            , td []
+            , td [ class "text-center" ]
                 [ span [ class ("label " ++ labelKind) ] [ text description ]
                 ]
             , td [] [ text taskName ]
             , td
                 -- Do not wrap buttons in this cell
-                [ style [ ( "white-space", "nowrap" ) ] ]
+                [ class "text-center", style [ ( "white-space", "nowrap" ) ] ]
                 [ a
                     [ href (logUrl instance taskName allocation StdOut)
                     , target "_blank"

--- a/webui/src/Views/InstanceView.elm
+++ b/webui/src/Views/InstanceView.elm
@@ -452,14 +452,14 @@ instanceAllocationRow instance index ( taskName, allocation ) =
                 [ a
                     [ href (logUrl instance taskName allocation StdOut)
                     , target "_blank"
-                    , class "btn btn-info btn-xs"
+                    , class "btn btn-default btn-xs"
                     ]
                     [ text "stdout" ]
                 , text " "
                 , a
                     [ href (logUrl instance taskName allocation StdErr)
                     , target "_blank"
-                    , class "btn btn-info btn-xs"
+                    , class "btn btn-default btn-xs"
                     ]
                     [ text "stderr" ]
                 ]

--- a/webui/webpack.config.js
+++ b/webui/webpack.config.js
@@ -13,9 +13,10 @@ module.exports = {
   devServer: {
     // We have a single-page application so do not navigate
     historyApiFallback: true,
-    // Forward API requests to the running backend
+    // Forward requests to API, downloads and websocket to the running backend
     proxy: {
       '/api': 'http://localhost:9000',
+      '/downloads': 'http://localhost:9000',
       '/ws': {
         target: 'ws://localhost:9000/',
         ws: true


### PR DESCRIPTION
Add buttons to download logs from the webui:

![](https://user-images.githubusercontent.com/224922/29411634-fb1f049c-8355-11e7-94d3-e6cb50133903.PNG)

The download link gets the last 500 KiB of the log; the `offset` query parameter lets you go back further. 

Builds upon #277 which needs to be merged before this one.