### PR TITLE
Show parameter types in front-end

### DIFF
--- a/webui/src/Views/ParameterFormView.elm
+++ b/webui/src/Views/ParameterFormView.elm
@@ -16,7 +16,6 @@ import Set exposing (Set)
 import Maybe
 import Maybe.Extra exposing (isJust, join)
 import Json.Decode
-import Regex exposing (contains, regex)
 import Tuple exposing (first, second)
 
 

--- a/webui/src/Views/ParameterFormView.elm
+++ b/webui/src/Views/ParameterFormView.elm
@@ -340,12 +340,9 @@ editParameterValueView instance parameterValues parameterInfos maybeInstancePara
                                             [ ( "background-color", Maybe.withDefault normalParamColor (Maybe.map (\v -> editingParamColor) maybeEditedValue) )
                                             ]
                                         ]
-                                        [ text parameterName ]
-                                  , span
-                                        [ class "input-group-addon" ]
-                                        [ icon
-                                            (dataTypeToIcon dataType)
-                                            [ title (dataTypeToTitle dataType) ]
+                                        [ text parameterName
+                                        , text " "
+                                        , sup [] [ text (dataTypeToTitle dataType) ]
                                         ]
                                   , input
                                         [ type_
@@ -618,12 +615,9 @@ newParameterValueView template parameterInfos maybeInstanceParameterForm enabled
                                             [ ( "background-color", Maybe.withDefault normalParamColor (Maybe.map (\v -> editingParamColor) maybeEditedValue) )
                                             ]
                                         ]
-                                        [ text parameterName ]
-                                  , span
-                                        [ class "input-group-addon" ]
-                                        [ icon
-                                            (dataTypeToIcon dataType)
-                                            [ title (dataTypeToTitle dataType) ]
+                                        [ text parameterName
+                                        , text " "
+                                        , sup [] [ text (dataTypeToTitle dataType) ]
                                         ]
                                   , input
                                         [ type_
@@ -718,33 +712,21 @@ getErrorMessage maybeValue paramName dataType =
             )
 
 
-dataTypeToIcon : ParameterType -> String
-dataTypeToIcon dataType =
-    case dataType of
-        StringParam ->
-            "glyphicon glyphicon-text-size"
-
-        RawParam ->
-            "glyphicon glyphicon-asterisk"
-
-        IntParam ->
-            "fa fa-hashtag"
-
-        DecimalParam ->
-            "glyphicon glyphicon-sound-5-1"
-
-
 dataTypeToTitle : ParameterType -> String
 dataTypeToTitle dataType =
-    case dataType of
-        StringParam ->
-            "String"
+    String.concat
+        [ "("
+        , case dataType of
+            StringParam ->
+                "String"
 
-        RawParam ->
-            "Unsafe String"
+            RawParam ->
+                "Raw"
 
-        IntParam ->
-            "Integer"
+            IntParam ->
+                "Integer"
 
-        DecimalParam ->
-            "Decimal"
+            DecimalParam ->
+                "Decimal"
+        , ")"
+        ]

--- a/webui/src/Views/ParameterFormView.elm
+++ b/webui/src/Views/ParameterFormView.elm
@@ -341,6 +341,12 @@ editParameterValueView instance parameterValues parameterInfos maybeInstancePara
                                             ]
                                         ]
                                         [ text parameterName ]
+                                  , span
+                                        [ class "input-group-addon" ]
+                                        [ icon
+                                            (dataTypeToIcon dataType)
+                                            [ title (dataTypeToTitle dataType) ]
+                                        ]
                                   , input
                                         [ type_
                                             (if (isSecret && (not secretVisible)) then
@@ -613,6 +619,12 @@ newParameterValueView template parameterInfos maybeInstanceParameterForm enabled
                                             ]
                                         ]
                                         [ text parameterName ]
+                                  , span
+                                        [ class "input-group-addon" ]
+                                        [ icon
+                                            (dataTypeToIcon dataType)
+                                            [ title (dataTypeToTitle dataType) ]
+                                        ]
                                   , input
                                         [ type_
                                             (if (isSecret && (not secretVisible)) then
@@ -704,3 +716,35 @@ getErrorMessage maybeValue paramName dataType =
                             Err _ ->
                                 Just (String.concat <| [ paramName, " must be ", dataTypeToString dataType ])
             )
+
+
+dataTypeToIcon : ParameterType -> String
+dataTypeToIcon dataType =
+    case dataType of
+        StringParam ->
+            "glyphicon glyphicon-text-size"
+
+        RawParam ->
+            "glyphicon glyphicon-asterisk"
+
+        IntParam ->
+            "fa fa-hashtag"
+
+        DecimalParam ->
+            "glyphicon glyphicon-sound-5-1"
+
+
+dataTypeToTitle : ParameterType -> String
+dataTypeToTitle dataType =
+    case dataType of
+        StringParam ->
+            "String"
+
+        RawParam ->
+            "Unsafe String"
+
+        IntParam ->
+            "Integer"
+
+        DecimalParam ->
+            "Decimal"

--- a/webui/src/Views/ParameterFormView.elm
+++ b/webui/src/Views/ParameterFormView.elm
@@ -195,12 +195,12 @@ templateSelectionView currentTemplate selectedTemplate templates instance maybeR
                   ]
                 ]
             )
-            (List.append
-                [ templateOption currentTemplate selectedTemplate currentTemplate ]
-                (templatesWithoutCurrentTemplate
+            (List.concat
+                [ [ templateOption currentTemplate selectedTemplate currentTemplate ]
+                , templatesWithoutCurrentTemplate
                     |> Dict.values
                     |> List.map (templateOption currentTemplate selectedTemplate)
-                )
+                ]
             )
 
 
@@ -326,76 +326,77 @@ editParameterValueView instance parameterValues parameterInfos maybeInstancePara
         in
             ( p
                 []
-                (List.append
-                    [ div
-                        [ classList
-                            [ ( "input-group", True )
-                            , ( "has-error", hasError )
-                            ]
-                        ]
-                        (List.append
-                            [ span
-                                [ class "input-group-addon"
-                                , style
-                                    [ ( "background-color", Maybe.withDefault normalParamColor (Maybe.map (\v -> editingParamColor) maybeEditedValue) )
-                                    ]
+                (List.concat
+                    [ [ div
+                            [ classList
+                                [ ( "input-group", True )
+                                , ( "has-error", hasError )
                                 ]
-                                [ text parameterName ]
-                            , input
-                                [ type_
-                                    (if (isSecret && (not secretVisible)) then
-                                        "password"
-                                     else
-                                        "text"
-                                    )
-                                , class "form-control"
-                                , attribute "aria-label" parameter
-                                , placeholder placeholderValue
-                                , value parameterValue
-                                , disabled (not enabled)
-                                , id <| String.concat [ "edit-instance-form-parameter-input-", instance.id, "-", instance.template.id, "-", parameter ]
-                                , onInput (EnterEditInstanceParameterValue instance parameter)
-                                ]
-                                []
                             ]
-                            (if (isSecret && enabled) then
-                                [ a
-                                    [ class "input-group-addon"
-                                    , attribute "role" "button"
-                                    , onClick (ToggleEditInstanceSecretVisibility instance.id parameter)
-                                    ]
-                                    [ icon
-                                        (String.concat
-                                            [ "glyphicon glyphicon-eye-"
-                                            , (if secretVisible then
-                                                "close"
-                                               else
-                                                "open"
-                                              )
+                            (List.concat
+                                [ [ span
+                                        [ class "input-group-addon"
+                                        , style
+                                            [ ( "background-color", Maybe.withDefault normalParamColor (Maybe.map (\v -> editingParamColor) maybeEditedValue) )
                                             ]
-                                        )
+                                        ]
+                                        [ text parameterName ]
+                                  , input
+                                        [ type_
+                                            (if (isSecret && (not secretVisible)) then
+                                                "password"
+                                             else
+                                                "text"
+                                            )
+                                        , class "form-control"
+                                        , attribute "aria-label" parameter
+                                        , placeholder placeholderValue
+                                        , value parameterValue
+                                        , disabled (not enabled)
+                                        , id <| String.concat [ "edit-instance-form-parameter-input-", instance.id, "-", instance.template.id, "-", parameter ]
+                                        , onInput (EnterEditInstanceParameterValue instance parameter)
+                                        ]
                                         []
+                                  ]
+                                , (if (isSecret && enabled) then
+                                    [ a
+                                        [ class "input-group-addon"
+                                        , attribute "role" "button"
+                                        , onClick (ToggleEditInstanceSecretVisibility instance.id parameter)
+                                        ]
+                                        [ icon
+                                            (String.concat
+                                                [ "glyphicon glyphicon-eye-"
+                                                , (if secretVisible then
+                                                    "close"
+                                                   else
+                                                    "open"
+                                                  )
+                                                ]
+                                            )
+                                            []
+                                        ]
+                                    , a
+                                        [ class "input-group-addon"
+                                        , attribute "role" "button"
+                                        , attribute
+                                            "onclick"
+                                            (String.concat
+                                                [ "copy('"
+                                                , parameterValue
+                                                , "')"
+                                                ]
+                                            )
+                                        ]
+                                        [ icon "glyphicon glyphicon-copy" [] ]
                                     ]
-                                , a
-                                    [ class "input-group-addon"
-                                    , attribute "role" "button"
-                                    , attribute
-                                        "onclick"
-                                        (String.concat
-                                            [ "copy('"
-                                            , parameterValue
-                                            , "')"
-                                            ]
-                                        )
-                                    ]
-                                    [ icon "glyphicon glyphicon-copy" [] ]
+                                   else
+                                    []
+                                  )
                                 ]
-                             else
-                                []
                             )
-                        )
-                    ]
-                    (case maybeErrMsg of
+                      ]
+                    , (case maybeErrMsg of
                         Nothing ->
                             []
 
@@ -406,7 +407,8 @@ editParameterValueView instance parameterValues parameterInfos maybeInstancePara
                                 ]
                                 [ text msg ]
                             ]
-                    )
+                      )
+                    ]
                 )
             , hasError
             )
@@ -595,78 +597,78 @@ newParameterValueView template parameterInfos maybeInstanceParameterForm enabled
         in
             ( p
                 []
-                (List.append
-                    [ div
-                        [ classList
-                            [ ( "input-group", True )
-                            , ( "has-error", hasError )
-                            ]
-                        , id <| String.concat [ "new-instance-form-input-group-", template.id, "-", parameter ]
-                        ]
-                        (List.append
-                            [ span
-                                [ class "input-group-addon"
-                                , style
-                                    [ ( "background-color", Maybe.withDefault normalParamColor (Maybe.map (\v -> editingParamColor) maybeEditedValue) )
-                                    ]
+                (List.concat
+                    [ [ div
+                            [ classList
+                                [ ( "input-group", True )
+                                , ( "has-error", hasError )
                                 ]
-                                [ text parameterName ]
-                            , input
-                                [ type_
-                                    (if (isSecret && (not secretVisible)) then
-                                        "password"
-                                     else
-                                        "text"
-                                    )
-                                , class "form-control"
-                                , attribute "aria-label" parameter
-                                , placeholder placeholderValue
-                                , value parameterValue
-                                , disabled (not enabled)
-                                , id <| String.concat [ "new-instance-form-parameter-input-", template.id, "-", parameter ]
-                                , onInput (EnterNewInstanceParameterValue template.id parameter)
-                                ]
-                                []
+                            , id <| String.concat [ "new-instance-form-input-group-", template.id, "-", parameter ]
                             ]
-                            (if (isSecret) then
-                                [ a
-                                    [ class "input-group-addon"
-                                    , attribute "role" "button"
-                                    , onClick (ToggleNewInstanceSecretVisibility template.id parameter)
-                                    , id <| String.concat [ "new-instance-form-parameter-secret-visibility-", template.id, "-", parameter ]
-                                    ]
-                                    [ icon
-                                        (String.concat
-                                            [ "glyphicon glyphicon-eye-"
-                                            , (if secretVisible then
-                                                "close"
-                                               else
-                                                "open"
-                                              )
+                            (List.concat
+                                [ [ span
+                                        [ class "input-group-addon"
+                                        , style
+                                            [ ( "background-color", Maybe.withDefault normalParamColor (Maybe.map (\v -> editingParamColor) maybeEditedValue) )
                                             ]
-                                        )
+                                        ]
+                                        [ text parameterName ]
+                                  , input
+                                        [ type_
+                                            (if (isSecret && (not secretVisible)) then
+                                                "password"
+                                             else
+                                                "text"
+                                            )
+                                        , class "form-control"
+                                        , attribute "aria-label" parameter
+                                        , placeholder placeholderValue
+                                        , value parameterValue
+                                        , disabled (not enabled)
+                                        , id <| String.concat [ "new-instance-form-parameter-input-", template.id, "-", parameter ]
+                                        , onInput (EnterNewInstanceParameterValue template.id parameter)
+                                        ]
                                         []
+                                  ]
+                                , if (isSecret) then
+                                    [ a
+                                        [ class "input-group-addon"
+                                        , attribute "role" "button"
+                                        , onClick (ToggleNewInstanceSecretVisibility template.id parameter)
+                                        , id <| String.concat [ "new-instance-form-parameter-secret-visibility-", template.id, "-", parameter ]
+                                        ]
+                                        [ icon
+                                            (String.concat
+                                                [ "glyphicon glyphicon-eye-"
+                                                , (if secretVisible then
+                                                    "close"
+                                                   else
+                                                    "open"
+                                                  )
+                                                ]
+                                            )
+                                            []
+                                        ]
+                                    , a
+                                        [ class "input-group-addon"
+                                        , attribute "role" "button"
+                                        , attribute
+                                            "onclick"
+                                            (String.concat
+                                                [ "copy('"
+                                                , parameterValue
+                                                , "')"
+                                                ]
+                                            )
+                                        ]
+                                        [ icon "glyphicon glyphicon-copy" [] ]
                                     ]
-                                , a
-                                    [ class "input-group-addon"
-                                    , attribute "role" "button"
-                                    , attribute
-                                        "onclick"
-                                        (String.concat
-                                            [ "copy('"
-                                            , parameterValue
-                                            , "')"
-                                            ]
-                                        )
-                                    ]
-                                    [ icon "glyphicon glyphicon-copy" [] ]
+                                  else
+                                    []
                                 ]
-                             else
-                                []
                             )
-                        )
-                    ]
-                    (maybeErrMsg
+                      ]
+                    , maybeErrMsg
                         |> Maybe.andThen
                             (\errMsg ->
                                 Just
@@ -678,7 +680,7 @@ newParameterValueView template parameterInfos maybeInstanceParameterForm enabled
                                     ]
                             )
                         |> Maybe.withDefault []
-                    )
+                    ]
                 )
             , hasError
             )


### PR DESCRIPTION
I think it's good to somehow show the parameter type in the front-end. Otherwise the user has to guess whether he has to enter a number or a string, e.g.

I'm not sure about the visuals. It looks a bit clumsy like this. @sohaibiftikhar what do you think? What do the others think?

![image](https://user-images.githubusercontent.com/3427394/39011002-9112e97a-4410-11e8-887f-9884c2e33ceb.png)

![image](https://user-images.githubusercontent.com/3427394/39362337-6433c660-4a26-11e8-9bff-a08a6d1b3f9e.png)

---

fixes #365 