### PR TITLE
Remove key 'id' when fixing old template confs

### DIFF
--- a/script/templates-0.7.0-to-0.8.0.py
+++ b/script/templates-0.7.0-to-0.8.0.py
@@ -17,11 +17,8 @@ def update_parameters(parameters, template_variables, instance_path, param_type)
     for variable in info_variables.union(template_variables):
         if variable not in info_variables:
             print("Adding missing variable '%s' to the parameterInfos of instance %s" % (variable, instance_path))
-            updated_parameters[variable] = ConfigFactory.from_dict({"id": variable, "type": param_type})
+            updated_parameters[variable] = ConfigFactory.from_dict({"type": param_type})
         else:
-            if 'id' not in updated_parameters[variable]:
-                print("Adding missing id for '%s' to the parameterInfos of instance %s" % (variable, instance_path))
-                updated_parameters[variable]["id"] = variable
             if "type" not in updated_parameters[variable]:
                 print("Adding missing type for '%s' to the parameterInfos of instance %s" % (variable, instance_path))
                 updated_parameters[variable]["type"] = param_type


### PR DESCRIPTION
In [template fix script](https://github.com/FRosner/cluster-broccoli/blob/master/script/templates-0.7.0-to-0.8.0.py) for v0.8.0 we are adding `id` to the template confs even though this is not strictly necessary.