### PR TITLE
fix(webui:prefix) to support play.http.context change

### DIFF
--- a/webui/src/Commands/Fetch.elm
+++ b/webui/src/Commands/Fetch.elm
@@ -2,4 +2,4 @@ module Commands.Fetch exposing (apiBaseUrl)
 
 
 apiBaseUrl =
-    "/api/v1"
+    "api/v1"


### PR DESCRIPTION
Support plays framework play.http.context which allows use of different base path for example `tools.example.com/broccoli` as base path and the api requests should go to `/broccoli/api/v1`

fixes #368